### PR TITLE
Fix critical bugs, add tests & CI, complete Mach-O analysis with ELF parity

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,48 @@
+name: CI
+
+on:
+  push:
+    branches: [ main, master ]
+  pull_request:
+    branches: [ main, master ]
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Install dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y cmake gcc build-essential
+
+    - name: Configure
+      run: cmake -S . -B build -DCMAKE_BUILD_TYPE=Release
+
+    - name: Build
+      run: cmake --build build
+
+    - name: Run tests
+      run: cmake --build build --target check
+
+  build-debug:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Install dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y cmake gcc build-essential
+
+    - name: Configure (Debug)
+      run: cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_FLAGS="-Wall -Wextra -Wpedantic -fsanitize=address,undefined" -DCMAKE_EXE_LINKER_FLAGS="-fsanitize=address,undefined"
+
+    - name: Build (Debug with sanitizers)
+      run: cmake --build build
+
+    - name: Run tests (with sanitizers)
+      run: cmake --build build --target check

--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,7 @@ a.out
 
 # CMake build directories
 build/
+build_*/
 cmake-build-*/
 */cmake-build-*/
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,53 @@
+# Changelog
+
+All notable changes to Baseer will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+
+## [0.3.0] - Unreleased
+
+### Added
+- **Test suite**: Unit tests for hashmap, baseer core, and bparser modules using a custom single-header test framework (`tests/`)
+- **CI pipeline**: GitHub Actions workflow with both Release and Debug+Sanitizer builds (`.github/workflows/ci.yml`)
+- **Logging system**: Centralized leveled logging (ERROR/WARN/INFO/DEBUG) via `utils/b_log.h`, controllable with `BASEER_LOG_LEVEL` environment variable
+- **Configurable decompiler path**: RetDec binary location can now be overridden via `BASEER_RETDEC_BIN` environment variable
+- **Mach-O build support**: Added Mach-O module sources and headers to CMakeLists.txt (was missing, causing linker errors)
+- **ELF input validation**: Bounds checking for section headers, program headers, string table indices, and section body reads against file size
+
+### Fixed
+- **Critical**: `memset(ctx, 0, sizeof(ctx))` in debugger only cleared 8 bytes (pointer size) instead of full `context` struct -- now uses `sizeof(context)`
+- **Critical**: `destroy_bp_sym()` used wrong loop variable (`ptr` instead of `ptr1`), causing symbol memory to never be freed
+- **Critical**: `handle_action()` had no return value on fallthrough path -- undefined behavior, now returns `false`
+- **Memory leak**: `parse_cmd()` leaked `line` buffer when process had exited (early return without `free(cmd)`)
+- **Memory leak**: CLI `args` command called `strdup()` without ever freeing previous arguments; now frees old args before overwriting
+- **Memory leak**: CLI `free(line)` was only called in the final `else` branch; now called on all `continue` paths
+- **Null deref**: `vmmap` command could dereference NULL if `/proc/pid/maps` failed to open; now checks `fopen` return
+- **Buffer overflow**: Replaced `sprintf` with `snprintf` in debugger for `/proc/pid/maps` path construction
+
+### Changed
+- **Security**: Replaced `system()` call in decompiler module with `fork()`/`execl()` to avoid shell injection risks
+- **Code organization**: Moved static arrays (`cmds[]`, `flags[]`, `regs_64[]`, `regs_32[]`) from `debugger.h` to `debugger.c` to prevent duplicate symbols across translation units
+
+### Removed
+- Large blocks of commented-out code in `bx_elf.c`, `debugger.c`, `bx_binhead.c`, `b_elf_metadata.c`, and `main.c`
+
+### Spelling Fixes
+- "Closeing" -> "Closing" in `baseer.c`
+- "faild" -> "failed" in `debugger.c`
+
+## [0.2.0] - 2025
+
+### Added
+- Mach-O format support (metadata parsing)
+- Interactive CLI with tab completion
+- Decompiler integration (RetDec)
+- ptrace-based debugger with breakpoints and register inspection
+- TAR archive metadata parsing
+
+## [0.1.0] - 2025
+
+### Added
+- Initial release
+- ELF metadata, disassembly, and section/symbol parsing
+- Modular callback-tree architecture
+- Memory and streaming file access modes

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,7 @@ set(LIBDIR "${CMAKE_INSTALL_PREFIX}/modules")
 include_directories(
     libs/libudis86
     libs/linenoise
+    libs/macho
 )
 
 # Udis86 sources
@@ -46,6 +47,9 @@ set(BX_ELF_DISASM_SRC modules/bx_elf_disasm/bx_elf_disasm.c)
 set(B_DEBUG_SRC modules/b_debugger/debugger.c)
 set(BX_TAR_SRC modules/bx_tar/bx_tar.c)
 set(BX_deElf_SRC modules/bx_deElf/bx_deElf.c)
+set(BX_MACHO_SRC modules/bx_macho/bx_macho.c)
+set(BX_MACHO_UTILS_SRC modules/bx_macho_utils/bx_macho_utils.c)
+set(B_MACHO_METADATA_SRC modules/b_macho_metadata/b_macho_metadata.c)
 
 # Main executable
 add_executable(baseer
@@ -61,6 +65,9 @@ add_executable(baseer
     ${BX_TAR_SRC}
     ${BX_deElf_SRC}
     ${BX_ELF_DISASM_SRC}
+    ${BX_MACHO_SRC}
+    ${BX_MACHO_UTILS_SRC}
+    ${B_MACHO_METADATA_SRC}
     ${UDIS86_SRC}
 )
 
@@ -99,6 +106,44 @@ install(PROGRAMS install_decompiler.sh DESTINATION ${BINDIR})
 
 # Create symlink (custom command)
 install(CODE "execute_process(COMMAND ${CMAKE_COMMAND} -E create_symlink ${BINDIR}/baseer /usr/bin/baseer)")
+
+# ========================= Tests =========================
+enable_testing()
+
+# Test: hashmap
+add_executable(test_hashmap
+    tests/test_hashmap.c
+    ${B_HASHMAP_SRC}
+)
+add_test(NAME test_hashmap COMMAND test_hashmap WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
+
+# Test: baseer core
+add_executable(test_baseer_core
+    tests/test_baseer_core.c
+    baseer.c
+    libs/linenoise/linenoise.c
+    ${B_HASHMAP_SRC}
+)
+target_include_directories(test_baseer_core PRIVATE libs/linenoise)
+add_test(NAME test_baseer_core COMMAND test_baseer_core WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
+
+# Test: bparser
+add_executable(test_bparser
+    tests/test_bparser.c
+    modules/bparser/bparser.c
+    baseer.c
+    libs/linenoise/linenoise.c
+    ${B_HASHMAP_SRC}
+)
+target_include_directories(test_bparser PRIVATE libs/linenoise)
+add_test(NAME test_bparser COMMAND test_bparser WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
+
+# Custom target to run all tests
+add_custom_target(check
+    COMMAND ${CMAKE_CTEST_COMMAND} --output-on-failure
+    DEPENDS test_hashmap test_baseer_core test_bparser
+    COMMENT "Running all tests"
+)
 
 # Uninstall target
 add_custom_target(uninstall

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,6 +50,7 @@ set(BX_deElf_SRC modules/bx_deElf/bx_deElf.c)
 set(BX_MACHO_SRC modules/bx_macho/bx_macho.c)
 set(BX_MACHO_UTILS_SRC modules/bx_macho_utils/bx_macho_utils.c)
 set(B_MACHO_METADATA_SRC modules/b_macho_metadata/b_macho_metadata.c)
+set(BX_MACHO_DISASM_SRC modules/bx_macho_disasm/bx_macho_disasm.c)
 
 # Main executable
 add_executable(baseer
@@ -68,6 +69,7 @@ add_executable(baseer
     ${BX_MACHO_SRC}
     ${BX_MACHO_UTILS_SRC}
     ${B_MACHO_METADATA_SRC}
+    ${BX_MACHO_DISASM_SRC}
     ${UDIS86_SRC}
 )
 
@@ -138,10 +140,21 @@ add_executable(test_bparser
 target_include_directories(test_bparser PRIVATE libs/linenoise)
 add_test(NAME test_bparser COMMAND test_bparser WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
 
+# Test: Mach-O
+add_executable(test_macho
+    tests/test_macho.c
+    modules/bparser/bparser.c
+    baseer.c
+    libs/linenoise/linenoise.c
+    ${B_HASHMAP_SRC}
+)
+target_include_directories(test_macho PRIVATE libs/linenoise)
+add_test(NAME test_macho COMMAND test_macho WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
+
 # Custom target to run all tests
 add_custom_target(check
     COMMAND ${CMAKE_CTEST_COMMAND} --output-on-failure
-    DEPENDS test_hashmap test_baseer_core test_bparser
+    DEPENDS test_hashmap test_baseer_core test_bparser test_macho
     COMMENT "Running all tests"
 )
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,15 @@
 # بصير (Baseer)
 
+![License](https://img.shields.io/badge/license-MIT-blue.svg)
+![Version](https://img.shields.io/badge/version-0.3.0-green.svg)
+![Language](https://img.shields.io/badge/language-C99-orange.svg)
+![Platform](https://img.shields.io/badge/platform-Linux-lightgrey.svg)
+
 **بصير (Baseer)** is a modular, extensible binary analysis framework written in C.
 It allows developers to inspect, disassemble, debug, and decompile binary files using a flexible callback system.
 Baseer identifies file formats using magic numbers and executes corresponding handlers dynamically.
 
-> ⚠️ Note: This project is still under development and may change frequently.
+> Note: This project is under active development. See [CHANGELOG.md](CHANGELOG.md) for recent changes.
 
 ---
 
@@ -98,8 +103,23 @@ cmake CMakeLists.txt && make && ./build/baseer examples/32bit_x86 -m | less -r
 
 ### Requirements
 - GCC
-- Linux environment (recommended)
-- make build system
+- CMake (>= 3.10)
+- Linux environment
+
+### Run Tests
+```bash
+cmake -S . -B build && cmake --build build --target check
+```
+
+--- 
+
+## Environment Variables
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `BASEER_RETDEC_BIN` | Path to RetDec decompiler binary | `/opt/baseer/decompiler/bin/retdec-decompiler` |
+| `BASEER_LOG_LEVEL` | Logging verbosity (0=error, 1=warn, 2=info, 3=debug) | `2` |
+| `BLOCK_LENGTH` | Number of bytes per hex dump line | `16` |
 
 --- 
 ## Install Baseer 

--- a/baseer.c
+++ b/baseer.c
@@ -15,8 +15,6 @@
 baseer_target_t *baseer_open(char *file_path, baseer_mode_t mode)
 {
     baseer_target_t *target = NULL;
-    size_t read;
-
     FILE *handler = NULL;
     RETURN_NULL_IF(file_path == NULL)
 
@@ -63,7 +61,7 @@ baseer_target_t *baseer_open(char *file_path, baseer_mode_t mode)
     return target;
 }
 
-/* =================== Closeing =================== */
+/* =================== Closing =================== */
 void baseer_close(baseer_target_t *target)
 {
     if(!target) return;
@@ -92,7 +90,7 @@ void baseer_close(baseer_target_t *target)
             }
             break;
         default:
-            fprintf(stderr, "[!] Failed in closeing \n");
+            fprintf(stderr, "[!] Failed in closing\n");
             break;
     }
     free(target);

--- a/baseer.h
+++ b/baseer.h
@@ -88,8 +88,6 @@ static inline int get_block_length(void)
     return DEFAULT_BLOCK_LENGTH;
 }
 
-
-
 /**
  * @brief Struct representing command-line inputs
  */

--- a/libs/macho/macho.h
+++ b/libs/macho/macho.h
@@ -608,8 +608,8 @@ struct fvmlib_command {
  * at runtime is exactly the same as used to built the program.
  */
 typedef struct dylib {
-    // union lc_str  name;			/* library's path name */
-    char* name;			/* library's path name */
+    uint32_t name_offset;		/* offset of library's path name from
+					   start of dylib_command */
     uint32_t timestamp;			/* library's build time stamp */
     uint32_t current_version;		/* library's current version number */
     uint32_t compatibility_version;	/* library's compatibility vers number*/
@@ -723,8 +723,8 @@ typedef struct dylinker_command {
 	uint32_t	cmd;		/* LC_ID_DYLINKER, LC_LOAD_DYLINKER or
 					   LC_DYLD_ENVIRONMENT */
 	uint32_t	cmdsize;	/* includes pathname string */
-        char *name;
-	// union lc_str    name;		/* dynamic linker's path name */
+	uint32_t	name_offset;	/* offset of dynamic linker's path name
+					   from start of this command */
 } dylinker_command;
 /*
  * Thread commands contain machine-specific data structures suitable for
@@ -1455,6 +1455,79 @@ struct note_command {
     uint64_t	offset;		/* file offset of this data */
     uint64_t	size;		/* length of data region */
 };
+
+/*
+ * Symbol table entry structures (nlist).
+ * These are used by LC_SYMTAB to describe symbol table entries.
+ */
+struct nlist {
+    uint32_t n_strx;   /* index into the string table */
+    uint8_t  n_type;   /* type flag */
+    uint8_t  n_sect;   /* section number or NO_SECT */
+    int16_t  n_desc;   /* see stab.h or mach-o/loader.h */
+    uint32_t n_value;  /* value of this symbol (or stab offset) */
+};
+
+struct nlist_64 {
+    uint32_t n_strx;   /* index into the string table */
+    uint8_t  n_type;   /* type flag */
+    uint8_t  n_sect;   /* section number or NO_SECT */
+    uint16_t n_desc;   /* description */
+    uint64_t n_value;  /* value of this symbol (or stab offset) */
+};
+
+/* Masks for n_type */
+#define N_STAB  0xe0  /* stab debugging entry */
+#define N_PEXT  0x10  /* private external */
+#define N_TYPE  0x0e  /* type mask */
+#define N_EXT   0x01  /* external (public) */
+
+/* Values for N_TYPE bits */
+#define N_UNDF  0x0   /* undefined, n_sect == NO_SECT */
+#define N_ABS   0x2   /* absolute, n_sect == NO_SECT */
+#define N_SECT  0xe   /* defined in section n_sect */
+#define N_PBUD  0xc   /* prebound undefined */
+#define N_INDR  0xa   /* indirect */
+
+#define NO_SECT 0     /* symbol not in any section */
+#define MAX_SECT 255  /* maximum section number */
+
+/* Reference type flags for n_desc */
+#define REFERENCE_TYPE              0x7
+#define REFERENCE_FLAG_UNDEFINED_NON_LAZY 0
+#define REFERENCE_FLAG_UNDEFINED_LAZY     1
+#define REFERENCE_FLAG_DEFINED            2
+#define REFERENCE_FLAG_PRIVATE_DEFINED     3
+#define REFERENCE_FLAG_PRIVATE_UNDEFINED_NON_LAZY 4
+#define REFERENCE_FLAG_PRIVATE_UNDEFINED_LAZY     5
+
+/* CPU type constants */
+#define CPU_TYPE_ANY       -1
+#define CPU_TYPE_X86       7
+#define CPU_TYPE_X86_64    (CPU_TYPE_X86 | 0x01000000)
+#define CPU_TYPE_ARM       12
+#define CPU_TYPE_ARM64     (CPU_TYPE_ARM | 0x01000000)
+#define CPU_TYPE_POWERPC   18
+#define CPU_TYPE_POWERPC64 (CPU_TYPE_POWERPC | 0x01000000)
+
+/* CPU subtype constants for x86 */
+#define CPU_SUBTYPE_X86_ALL    3
+#define CPU_SUBTYPE_X86_64_ALL 3
+#define CPU_SUBTYPE_X86_64_H   8
+
+/* CPU subtype constants for ARM */
+#define CPU_SUBTYPE_ARM_ALL    0
+#define CPU_SUBTYPE_ARM64_ALL  0
+#define CPU_SUBTYPE_ARM64E     2
+
+/* Byte swap helper (guard against redefinition) */
+#ifndef NXSwapInt
+#define NXSwapInt(x) ((uint32_t)( \
+    (((uint32_t)(x) & 0xff000000u) >> 24) | \
+    (((uint32_t)(x) & 0x00ff0000u) >>  8) | \
+    (((uint32_t)(x) & 0x0000ff00u) <<  8) | \
+    (((uint32_t)(x) & 0x000000ffu) << 24)))
+#endif
 
 #endif	/* macho.h */
 

--- a/main.c
+++ b/main.c
@@ -1,5 +1,4 @@
 #include "baseer.h"
-// #include "modules/default/bx_default.h"
 #include "modules/binhead/bx_binhead.h"
 #include "utils/ui.h"
 #include "utils/b_CLI.h"
@@ -39,7 +38,6 @@ int main(int argc, char** args)
 
 
         inputs input = {&argc, args};
-        // create hashmap of any hashmaps needed by baseer extentions to used it for other extentions...
         input.map = create_map();
  
         parse_args(&input);

--- a/modules/b_debugger/debugger.c
+++ b/modules/b_debugger/debugger.c
@@ -683,11 +683,128 @@ void dis_ctx(context *ctx){
 
 
 /**
- * @brief Initialize the debugger context from a parsed ELF binary.
+ * @brief Load symbols from a Mach-O binary into the debugger context.
+ */
+static void init_macho_symbols(bparser *target, context *ctx)
+{
+	unsigned char *block = (unsigned char *)target->block;
+	uint32_t magic = *(uint32_t *)block;
+	bool is_64 = (magic == 0xfeedfacf);
+	size_t hdr_size = is_64 ? sizeof(Elf64_Ehdr) : sizeof(Elf32_Ehdr); /* placeholder for header skip */
+
+	/* Parse Mach-O header to get ncmds and sizeofcmds */
+	uint32_t ncmds, sizeofcmds;
+	unsigned char *cmd_ptr;
+	if (is_64) {
+		hdr_size = 32; /* sizeof(mach_header_64) */
+		ncmds = *(uint32_t *)(block + 16);
+		sizeofcmds = *(uint32_t *)(block + 20);
+		ctx->arch = 64;
+	} else {
+		hdr_size = 28; /* sizeof(mach_header) */
+		ncmds = *(uint32_t *)(block + 12);
+		sizeofcmds = *(uint32_t *)(block + 16);
+		ctx->arch = 32;
+	}
+
+	if (hdr_size + sizeofcmds > target->size) return;
+	cmd_ptr = block + hdr_size;
+	unsigned char *end_ptr = block + target->size;
+
+	/* Find LC_SYMTAB (cmd=0x2) and LC_MAIN (cmd=0x80000028) for entry point */
+	uint32_t symoff = 0, nsyms = 0, stroff = 0, strsize = 0;
+	uint64_t entry_off = 0;
+
+	for (uint32_t i = 0; i < ncmds; i++) {
+		if (cmd_ptr + 8 > end_ptr) break;
+		uint32_t cmd = *(uint32_t *)cmd_ptr;
+		uint32_t cmdsize = *(uint32_t *)(cmd_ptr + 4);
+		if (cmdsize < 8 || cmd_ptr + cmdsize > end_ptr) break;
+
+		if (cmd == 0x2) { /* LC_SYMTAB */
+			symoff  = *(uint32_t *)(cmd_ptr + 8);
+			nsyms   = *(uint32_t *)(cmd_ptr + 12);
+			stroff  = *(uint32_t *)(cmd_ptr + 16);
+			strsize = *(uint32_t *)(cmd_ptr + 20);
+		} else if (cmd == (0x28 | 0x80000000)) { /* LC_MAIN */
+			entry_off = *(uint64_t *)(cmd_ptr + 8);
+		}
+		cmd_ptr += cmdsize;
+	}
+
+	/* Set entry to base + entry offset (Mach-O is always PIE on modern systems) */
+	ctx->entry = ctx->base + entry_off;
+	ctx->pie = false;
+
+	/* Load symbols from nlist */
+	if (nsyms == 0 || symoff == 0 || stroff == 0) return;
+
+	if (is_64) {
+		size_t nlist_size = 16; /* sizeof(nlist_64) */
+		if (symoff + nsyms * nlist_size > target->size) return;
+		if (stroff + strsize > target->size) return;
+
+		unsigned char *nl = block + symoff;
+		char *strs = (char *)(block + stroff);
+
+		for (uint32_t j = 0; j < nsyms; j++) {
+			uint32_t n_strx = *(uint32_t *)(nl + j * nlist_size);
+			uint8_t  n_type = *(uint8_t  *)(nl + j * nlist_size + 4);
+			uint64_t n_value = *(uint64_t *)(nl + j * nlist_size + 8);
+
+			/* Only defined symbols (N_SECT=0xe, not stab) */
+			if ((n_type & 0xe0) != 0 || (n_type & 0x0e) != 0x0e || n_value == 0)
+				continue;
+
+			if (n_strx >= strsize) continue;
+			char *name = strs + n_strx;
+			if (*name == '\0') continue;
+
+			sym_list *sym = malloc(sizeof(sym_list));
+			if (!sym) break;
+			sym->name = strdup(name);
+			sym->addr = ctx->base + n_value; /* relocated */
+			sym->next = NULL;
+			if (ctx->sym == NULL) { ctx->sym = sym; }
+			else { sym_list *l = ctx->sym; while (l->next) l = l->next; l->next = sym; }
+		}
+	} else {
+		size_t nlist_size = 12; /* sizeof(nlist) */
+		if (symoff + nsyms * nlist_size > target->size) return;
+		if (stroff + strsize > target->size) return;
+
+		unsigned char *nl = block + symoff;
+		char *strs = (char *)(block + stroff);
+
+		for (uint32_t j = 0; j < nsyms; j++) {
+			uint32_t n_strx = *(uint32_t *)(nl + j * nlist_size);
+			uint8_t  n_type = *(uint8_t  *)(nl + j * nlist_size + 4);
+			uint32_t n_value = *(uint32_t *)(nl + j * nlist_size + 8);
+
+			if ((n_type & 0xe0) != 0 || (n_type & 0x0e) != 0x0e || n_value == 0)
+				continue;
+
+			if (n_strx >= strsize) continue;
+			char *name = strs + n_strx;
+			if (*name == '\0') continue;
+
+			sym_list *sym = malloc(sizeof(sym_list));
+			if (!sym) break;
+			sym->name = strdup(name);
+			sym->addr = ctx->base + n_value;
+			sym->next = NULL;
+			if (ctx->sym == NULL) { ctx->sym = sym; }
+			else { sym_list *l = ctx->sym; while (l->next) l = l->next; l->next = sym; }
+		}
+	}
+}
+
+/**
+ * @brief Initialize the debugger context from a parsed binary.
  *
- * Reads ELF headers and symbol tables to populate context values.
+ * Reads ELF or Mach-O headers and symbol tables to populate context values.
  *
- * @param target Pointer to binary parser structure with ELF data.
+ * @param target Pointer to binary parser structure with file data.
  * @param ctx Pointer to debugger context to initialize.
  */
 void init_values(bparser *target, context *ctx){
@@ -700,13 +817,30 @@ void init_values(bparser *target, context *ctx){
 	memset(list, 0, sizeof(bp_list));
 	list->counter = 0;
 	ctx->list = list;
-	Elf64_Ehdr *ehdr = (Elf64_Ehdr*)target->block;
+
 	snprintf(mmaps, sizeof(mmaps), "/proc/%d/maps", ctx->pid);
 	FILE *file = fopen(mmaps,"r");
+	if (!file) {
+		fprintf(stderr, "failed to open process maps\n");
+		return;
+	}
 	size_t size = 0;
 	getdelim(&ctx->mmaps,&size,'\0' , file);
 	fclose(file);
 	sscanf(ctx->mmaps, "%lx", &ctx->base);
+
+	/* Detect file format by magic bytes */
+	if (target->size >= 4) {
+		uint32_t magic = *(uint32_t *)target->block;
+		if (magic == 0xfeedface || magic == 0xfeedfacf) {
+			/* Mach-O binary */
+			init_macho_symbols(target, ctx);
+			return;
+		}
+	}
+
+	/* ELF binary */
+	Elf64_Ehdr *ehdr = (Elf64_Ehdr*)target->block;
 	if(ehdr->e_type == ET_EXEC){
 		ctx->entry = ehdr->e_entry;
 		ctx->pie = true ;

--- a/modules/b_debugger/debugger.c
+++ b/modules/b_debugger/debugger.c
@@ -13,6 +13,76 @@
 #include "debugger.h"
 #include <sys/ptrace.h>
 #include "../bx_elf_utils/bx_elf_utils.h"
+
+/* Command dispatch table */
+static func_list cmds[] = {
+    {"bp",setBP},
+    {"dp",delBP},
+    {"lp",listBP},
+    {"so",step_over},
+    {"x",examin_mem},
+    {"set",set_mem_reg},
+    {"h",handle_action},
+    {"c",handle_action},
+    {"q",handle_action},
+    {"si",handle_action},
+    {"vmmap",handle_action},
+    {"i",handle_action},
+};
+
+/* CPU flags bit positions */
+static pos_name flags[] = {
+    {"CF",0},
+    {"PF",2},
+    {"AF",4},
+    {"ZF",6},
+    {"SF",7},
+    {"DF",10},
+    {"OF",11},
+};
+
+/* 64-bit register name-to-offset mappings */
+static pos_name regs_64[] = {
+    {"RAX ",0x50},
+    {"RDX ",0x60},
+    {"RCX ",0x58},
+    {"RBX ",0x28},
+    {"RDI ",0x80},
+    {"RSI ",0x68},
+    {"R8  ",0x48},
+    {"R9  ",0x40},
+    {"R10 ",0x38},
+    {"R11 ",0x30},
+    {"R12 ",0x18},
+    {"R13 ",0x10},
+    {"R14 ",0x8},
+    {"R15 ",0},
+    {"RSP ",0x98},
+    {"RBP ",0x20},
+    {"RIP ",0x80},
+};
+
+/* 32-bit register name-to-offset mappings */
+static pos_name regs_32[] = {
+    {"EAX ",0x50},
+    {"EDX ",0x60},
+    {"ECX ",0x58},
+    {"EBX ",0x28},
+    {"EDI ",0x80},
+    {"ESI ",0x68},
+    {"R8d  ",0x48},
+    {"R9d  ",0x40},
+    {"R10d ",0x38},
+    {"R11d ",0x30},
+    {"R12d ",0x18},
+    {"R13d ",0x10},
+    {"R14d ",0x8},
+    {"R15d ",0},
+    {"ESP ",0x98},
+    {"EBP ",0x20},
+    {"EIP ",0x80},
+};
+
 /**
  * @file debugger.c
  * @brief Implementation of a lightweight debugger for ELF binaries using ptrace.
@@ -60,8 +130,10 @@ void parse_cmd(context *ctx){
 	uint32_t len = sizeof(cmds)/sizeof(func_list); 
 	for (int i = 0; i< len ; i++) {
 		if(strcmp(ctx->cmd.op,cmds[i].cmd) == 0){
-			if(ctx->base == 0 && (strcmp(ctx->cmd.op,"q") != 0) )
+			if(ctx->base == 0 && (strcmp(ctx->cmd.op,"q") != 0) ){
+				free(cmd);
 				return;
+			}
 			flag = cmds[i].func(ctx,(void*)args);
 			break;
 
@@ -97,13 +169,20 @@ bool handle_action(context *ctx,void *args){
 		return true;
 	}else if (strcmp(ctx->cmd.op,"vmmap") == 0) {
 		free(ctx->mmaps);
+		ctx->mmaps = NULL;
 		char mmaps[512] = {0};
-		sprintf(mmaps, "/proc/%d/maps", ctx->pid);
+		snprintf(mmaps, sizeof(mmaps), "/proc/%d/maps", ctx->pid);
 		FILE *file = fopen(mmaps,"r");
+		if (!file) {
+			ERROR("failed to open process maps\n");
+			ctx->do_wait = false;
+			return true;
+		}
 		size_t size = 0;
 		getdelim(&ctx->mmaps,&size,'\0' , file);
 		fclose(file);
-		printf("%s\n",ctx->mmaps);
+		if (ctx->mmaps)
+			printf("%s\n",ctx->mmaps);
 		ctx->do_wait = false;
 		return true;
 	}else if (strcmp(ctx->cmd.op,"c") == 0) {
@@ -130,6 +209,7 @@ bool handle_action(context *ctx,void *args){
 		return true;
 	}
 
+	return false;
 }
 
 /**
@@ -163,9 +243,9 @@ void print_helpCMD(){
 bool set_mem_reg(context *ctx,void *args){
 	ctx->do_wait = false;
 	char *arg = (char*)args;
-	if(arg == '\0')
+	if(!arg || *arg == '\0')
 		return false;
-	while(arg != '\0' && isspace((unsigned char)*arg))arg++;
+	while(*arg != '\0' && isspace((unsigned char)*arg))arg++;
 	uint32_t counter = 0 ;
 	char *tokens[2] = {0};
 	char *token = strtok(arg,"=");
@@ -405,9 +485,9 @@ bool setBP(context *ctx, void* args){
 	char *arg = (char*)args;
 	ctx->do_wait = false;
 
-	if(arg == '\0')
+	if(!arg || *arg == '\0')
 		return false;
-	while(arg != '\0' && isspace((unsigned char)*arg))arg++;
+	while(*arg != '\0' && isspace((unsigned char)*arg))arg++;
 
 	char *token = strtok(arg, " ");
 	if(token == NULL){
@@ -616,11 +696,12 @@ void init_values(bparser *target, context *ctx){
 	ctx->do_wait = false;
 	ctx->do_exit = false;
 	ctx->sym = NULL;
+	ctx->mmaps = NULL;
 	memset(list, 0, sizeof(bp_list));
 	list->counter = 0;
 	ctx->list = list;
 	Elf64_Ehdr *ehdr = (Elf64_Ehdr*)target->block;
-	sprintf(mmaps, "/proc/%d/maps", ctx->pid);
+	snprintf(mmaps, sizeof(mmaps), "/proc/%d/maps", ctx->pid);
 	FILE *file = fopen(mmaps,"r");
 	size_t size = 0;
 	getdelim(&ctx->mmaps,&size,'\0' , file);
@@ -722,8 +803,9 @@ void destroy_bp_sym(context *ctx){
 
 	sym_list *ptr1 = ctx->sym;
 	sym_list *temp = NULL;
-	while (ptr != NULL) {
+	while (ptr1 != NULL) {
 		temp = ptr1->next;
+		free(ptr1->name);
 		free(ptr1);
 		ptr1 = temp;
 	}
@@ -756,44 +838,19 @@ void destroy_all(context *ctx){
  */
 bool b_debugger(bparser *target, void *arg){
 
-    // printf("from debugger...\n");
-    // hashmap_t *maps = ((inputs*)arg) -> map;
-    // if((hashmap_t*)get(maps, "sections") != NULL){
-    //     hashmap_t *map = (hashmap_t*)get(maps, "sections");
-    //     printf("there are sections...\n");
-    // }
-
-    // // 64 bit
-    // if((hashmap_t*)get(maps, "symbols") != NULL){
-    //     hashmap_t *symbols = (hashmap_t*)get(maps, "symbols");
-    //     printf("there are symbols...\n");
-    //     // for (int i = 0; i < TABLE_SIZE; i++) {
-    //     //     bht_node_t *bht_node = symbols->buckets[i];
-    //     //     while (bht_node != NULL) {
-    //     //         bht_node_t *temp = bht_node;
-    //     //         bht_node = bht_node->next;
-    //     //         printf("symbol name: %s\n", temp -> name);
-    //     //     }
-    //     // }
-        
-    //     if((Elf64_Sym*)get(symbols, "main") != NULL){
-    //         Elf64_Sym* func = (Elf64_Sym*)get(symbols, "main");
-    //         printf("offset: %llx\n size: %d\n", func->st_value, func->st_size);
-    //     }
-    // }
-
-
-
-
 	setbuf(stdout, NULL);
 	int argc = *((inputs*)arg) -> argc;
 	char** args = ((inputs*)arg) -> args;
 	context *ctx  = malloc(sizeof(context));
-	memset(ctx, 0, sizeof(ctx));
+	if (!ctx) {
+		fprintf(stderr, "failed to allocate debugger context\n");
+		return false;
+	}
+	memset(ctx, 0, sizeof(context));
 	int stats = 0;
 	int pid = fork();
 	if (pid < 0 ){
-		printf("faild to fork");
+		fprintf(stderr, "failed to fork\n");
 		return false;
 	}else if (pid == 0) {
 		int fd = memfd_create(args[1], MFD_CLOEXEC);

--- a/modules/b_debugger/debugger.h
+++ b/modules/b_debugger/debugger.h
@@ -193,66 +193,6 @@ bool handle_action(context *ctx, void *args);
  * @brief Parse and dispatch a command from the user.
  */
 void parse_cmd(context *ctx);
-static func_list cmds[] = {
-    {"bp",setBP},
-    {"dp",delBP},
-    {"lp",listBP},
-    {"so",step_over},
-    {"x",examin_mem},
-    {"set",set_mem_reg},
-    {"h",handle_action},
-    {"c",handle_action},
-    {"q",handle_action},
-    {"si",handle_action},
-    {"vmmap",handle_action},
-    {"i",handle_action},
-};
-static pos_name flags[] = {
-    {"CF",0},
-    {"PF",2},
-    {"AF",4},
-    {"ZF",6},
-    {"SF",7},
-    {"DF",10},
-    {"OF",11},
-};
-static pos_name regs_64[] = {
-{"RAX ",0x50},
-{"RDX ",0x60},
-{"RCX ",0x58},
-{"RBX ",0x28},
-{"RDI ",0x80},
-{"RSI ",0x68},
-{"R8  ",0x48},
-{"R9  ",0x40},
-{"R10 ",0x38},
-{"R11 ",0x30},
-{"R12 ",0x18},
-{"R13 ",0x10},
-{"R14 ",0x8},
-{"R15 ",0},
-{"RSP ",0x98},
-{"RBP ",0x20},
-{"RIP ",0x80},
-};
-static pos_name regs_32[] = {
-{"EAX ",0x50},
-{"EDX ",0x60},
-{"ECX ",0x58},
-{"EBX ",0x28},
-{"EDI ",0x80},
-{"ESI ",0x68},
-{"R8d  ",0x48},
-{"R9d  ",0x40},
-{"R10d ",0x38},
-{"R11d ",0x30},
-{"R12d ",0x18},
-{"R13d ",0x10},
-{"R14d ",0x8},
-{"R15d ",0},
-{"ESP ",0x98},
-{"EBP ",0x20},
-{"EIP ",0x80},
-};
+
 #endif /* DEBUG_H */
 

--- a/modules/b_elf_metadata/b_elf_metadata.c
+++ b/modules/b_elf_metadata/b_elf_metadata.c
@@ -113,54 +113,51 @@ void dump_elf64hdr(Elf64_Ehdr *elf)
  */
 void dump_elf32_shdr(Elf32_Ehdr* elf, Elf32_Shdr* shdrs, bparser* parser, void* arg) 
 {
+    /* Validate string table section bounds */
     Elf32_Shdr shstr = shdrs[elf->e_shstrndx];
+    if (shstr.sh_offset + shstr.sh_size > parser->size) {
+        fprintf(stderr, COLOR_RED "[!] Section string table extends beyond file bounds\n" COLOR_RESET);
+        return;
+    }
     const char* shstrtab = (const char*)(parser->block + shstr.sh_offset);
 
     printf(COLOR_BLUE "\n=== Section Headers ===\n" COLOR_RESET);
     print_section_header_legend();
 
-    // ======================================= init maps  =================================================
-    // create hashmap of section headers to retreve the specifa name of section header needed
-    // hashmap_t *map = create_map();
+    /* Initialize section and symbol hashmaps */
     hashmap_t *maps = ((inputs*)arg) -> map;
     if((hashmap_t*)get(maps, "sections") == NULL){
         insert(maps, "sections", create_map());
     }
-
     if((hashmap_t*)get(maps, "symbols") == NULL){
         insert(maps, "symbols", create_map());
     }
-
-    // ======================================= init maps  =================================================
 
     hashmap_t *map = (hashmap_t*)get(maps, "sections");
     hashmap_t *symbols = (hashmap_t*)get(maps, "symbols");
 
     for (int i = 0; i < elf->e_shnum; i++) {
-        // ============================ BEGIN SECTION METADATA =============================
-        // Section name
         const char* name = &shstrtab[shdrs[i].sh_name];
-
-        // Type
         const char* type_str = sh_type_to_str(shdrs[i].sh_type);
 
-        // Insert section header pointers into a hashmap for quick retrieval by name
         if((Elf32_Shdr*)get(map, name) == NULL){
             insert(map, name, &shdrs[i]);
         }
 
-        // Flags
         char flags[64] = "";
         format_sh_flags(shdrs[i].sh_flags, flags, sizeof(flags));
         printf("\n");
 
         print_section_header_metadata_32bit(i, name, type_str, flags, shdrs);
-        // ============================ END SECTION METADATA =============================
-        
-
-        // ============================ BEGIN SECTION BODY =============================
-        long int offset = shdrs[i].sh_offset;
         if (shdrs[i].sh_size > 0) {
+
+            if(shdrs[i].sh_offset > parser->size) {
+                shdrs[i].sh_offset = 0;
+            }
+            if(shdrs[i].sh_size > parser->size) {
+                shdrs[i].sh_size = parser->size;
+            }
+
             void* block = malloc(shdrs[i].sh_size);
             bparser_read(parser, block, shdrs[i].sh_offset, shdrs[i].sh_size);
             unsigned char* ptr = (unsigned char*)block;
@@ -174,6 +171,7 @@ void dump_elf32_shdr(Elf32_Ehdr* elf, Elf32_Shdr* shdrs, bparser* parser, void* 
     for (int i = 0; i < elf->e_shnum; i++) {
         Elf32_Shdr curr_shd = shdrs[i];
         if(curr_shd.sh_link == 0) continue;
+        if(curr_shd.sh_link >= elf->e_shnum) continue;
         Elf32_Shdr linked_shd = shdrs[curr_shd.sh_link];
 
         // check is it table type and have like `SYMTAB` `DYNSYMTAB` `REL` `RELA` and so on... and there LINK section for names.
@@ -203,14 +201,7 @@ void dump_elf32_shdr(Elf32_Ehdr* elf, Elf32_Shdr* shdrs, bparser* parser, void* 
 
 
     Elf32_Shdr *symtab, *strtab;
-    // if((symtab = (Elf32_Shdr*)get(map, ".dynsym")) != NULL && (strtab = (Elf32_Shdr*)get(map, ".dynstr")) != NULL) {
-    //     print_symbols_32bit(parser, elf, shdrs, symtab, strtab);
-    //     printf("\n\n");
-    // }
-
     if((symtab = (Elf32_Shdr*)get(map, ".symtab")) != NULL && (strtab = (Elf32_Shdr*)get(map, ".strtab")) != NULL) {
-
-        // Insert symbols in hashmap
         Elf32_Sym *syms = (Elf32_Sym *)(parser->block + symtab->sh_offset);
         const char *strs = (const char *)(parser->block + strtab->sh_offset);
         unsigned int count = symtab->sh_size / sizeof(Elf32_Sym);
@@ -220,21 +211,8 @@ void dump_elf32_shdr(Elf32_Ehdr* elf, Elf32_Shdr* shdrs, bparser* parser, void* 
                 insert(symbols, name, &syms[i]);
             }
         }
-        // print_symbols_32bit(parser, elf, shdrs, symtab, strtab);
         printf("\n\n");
     }
-
-    // if((symtab = (Elf32_Shdr*)get(map, ".rel.plt")) != NULL) {
-    //     print_rela_32bit(parser, elf, shdrs, symtab, strtab);
-    //     printf("\n\n");
-    // }
-
-    // if((symtab = (Elf32_Shdr*)get(map, ".rela.plt")) != NULL) {
-    //     print_rela_32bit(parser, elf, shdrs, symtab, strtab);
-    //     printf("\n\n");
-    // }
-
-    // free_map(map);
 }
 
 /**
@@ -264,53 +242,52 @@ void dump_elf32_shdr(Elf32_Ehdr* elf, Elf32_Shdr* shdrs, bparser* parser, void* 
  */
 void dump_elf64_shdr(Elf64_Ehdr* elf , Elf64_Shdr* shdrs, bparser* parser, void* arg) 
 {
+    /* Validate string table section bounds */
     Elf64_Shdr shstr = shdrs[elf->e_shstrndx];
+    if (shstr.sh_offset + shstr.sh_size > parser->size) {
+        fprintf(stderr, COLOR_RED "[!] Section string table extends beyond file bounds\n" COLOR_RESET);
+        return;
+    }
     const char* shstrtab = (const char*)(parser->block + shstr.sh_offset);
     printf(COLOR_BLUE "\n=== Section Headers ===\n" COLOR_RESET);
     print_section_header_legend();
 
 
-    // ======================================= init maps  =================================================
-    // create hashmap of section headers to retreve the specifa name of section header needed
-    // hashmap_t *map = create_map();
+    /* Initialize section and symbol hashmaps */
     hashmap_t *maps = ((inputs*)arg) -> map;
     if((hashmap_t*)get(maps, "sections") == NULL){
         insert(maps, "sections", create_map());
     }
-
     if((hashmap_t*)get(maps, "symbols") == NULL){
         insert(maps, "symbols", create_map());
     }
 
-    // ======================================= init maps  =================================================
-
     hashmap_t *map = (hashmap_t*)get(maps, "sections");
     hashmap_t *symbols = (hashmap_t*)get(maps, "symbols");
 
-
     for (int i = 0; i < elf->e_shnum; i++) {
-        // ============================ BEGIN SECTION METADATA =============================
-        // Section name
         const char* name = &shstrtab[shdrs[i].sh_name];
-
-        // Type
         const char* type_str = sh_type_to_str(shdrs[i].sh_type);
 
-        // Insert section header pointers into a hashmap for quick retrieval by name
         if((Elf64_Shdr*)get(map, name) == NULL){
             insert(map, name, &shdrs[i]);
         }
 
-        // Flags
         char flags[64] = "";
         format_sh_flags(shdrs[i].sh_flags, flags, sizeof(flags));
         printf("\n");       
 
         print_section_header_metadata_64bit(i, name, type_str, flags, shdrs);
-        // ============================ END SECTION METADATA =============================
-
-        // ============================ BEGIN SECTION BODY =============================
         if (shdrs[i].sh_size > 0) {
+
+            if(shdrs[i].sh_offset > parser->size) {
+                shdrs[i].sh_offset = 0;
+            }
+            if(shdrs[i].sh_size > parser->size) {
+                shdrs[i].sh_size = parser->size;
+            }
+
+
             void* block = malloc(shdrs[i].sh_size);
             bparser_read(parser, block, shdrs[i].sh_offset, shdrs[i].sh_size);
             unsigned char* ptr = (unsigned char*)block;
@@ -326,6 +303,7 @@ void dump_elf64_shdr(Elf64_Ehdr* elf , Elf64_Shdr* shdrs, bparser* parser, void*
     for (int i = 0; i < elf->e_shnum; i++) {
         Elf64_Shdr curr_shd = shdrs[i];
         if(curr_shd.sh_link == 0) continue;
+        if(curr_shd.sh_link >= elf->e_shnum) continue;
         Elf64_Shdr linked_shd = shdrs[curr_shd.sh_link];
 
         // check is it table type and have like `SYMTAB` `DYNSYMTAB` `REL` `RELA` and so on... and there LINK section for names.
@@ -425,6 +403,14 @@ void dump_elf32_phdr(Elf32_Ehdr *elf, Elf32_Phdr* phdr, bparser*parser)
 
         // ============================ BEGIN PROGRAM BODY =============================
         if (phdr[i].p_filesz > 0) {
+
+            if(phdr[i].p_offset > parser->size) {
+                phdr[i].p_offset = 0;
+            }
+            if(phdr[i].p_filesz > parser->size) {
+                phdr[i].p_filesz = parser->size;
+            }
+
             void *block = malloc(phdr[i].p_filesz);
             bparser_read(parser, block, phdr[i].p_offset, phdr[i].p_filesz);
             unsigned char* ptr = (unsigned char*)block;
@@ -489,6 +475,14 @@ void dump_elf64_phdr(Elf64_Ehdr *elf, Elf64_Phdr* phdr, bparser*parser)
         
         // ============================ BEGIN PROGRAM BODY =============================
         if (phdr[i].p_filesz > 0) {
+
+            if(phdr[i].p_offset > parser->size) {
+                phdr[i].p_offset = 0;
+            }
+            if(phdr[i].p_filesz > parser->size) {
+                phdr[i].p_filesz = parser->size;
+            }
+
             void *block = malloc(phdr[i].p_filesz);
             bparser_read(parser, block, phdr[i].p_offset, phdr[i].p_filesz);
             unsigned char* ptr = (unsigned char*)block;
@@ -525,14 +519,16 @@ void dump_elf64_phdr(Elf64_Ehdr *elf, Elf64_Phdr* phdr, bparser*parser)
  *      dump_elf64hdr(), dump_elf64_shdr(), dump_elf64_phdr()
  */
 
-// #define (n, pfsz, value) \
-//     Elf##pfsz_Shdr *n = #value;
-// READ_BYTES(md, 64)
-
-
 bool print_meta_data(bparser* parser, void* arg) 
 {
     unsigned char *data = (unsigned char*) parser->block;
+
+    /* Minimum size: ELF identification bytes (EI_NIDENT = 16) */
+    if (!data || parser->size < EI_NIDENT) {
+        fprintf(stderr, COLOR_RED "[!] File too small to be a valid ELF binary\n" COLOR_RESET);
+        return false;
+    }
+
     char bit_type = data[EI_CLASS];
     char endian   = data[EI_DATA];
 
@@ -548,7 +544,28 @@ bool print_meta_data(bparser* parser, void* arg)
     }
 
     if (bit_type == ELFCLASS32) {
+        if (parser->size < sizeof(Elf32_Ehdr)) {
+            fprintf(stderr, COLOR_RED "[!] File too small for 32-bit ELF header\n" COLOR_RESET);
+            return false;
+        }
         Elf32_Ehdr* elf = (Elf32_Ehdr*) data;
+
+        /* Validate section header table bounds */
+        if (elf->e_shoff > 0 && (elf->e_shoff + (size_t)elf->e_shnum * elf->e_shentsize > parser->size)) {
+            fprintf(stderr, COLOR_RED "[!] Section header table extends beyond file bounds\n" COLOR_RESET);
+            elf->e_shnum = 0;
+        }
+        /* Validate program header table bounds */
+        if (elf->e_phoff > 0 && (elf->e_phoff + (size_t)elf->e_phnum * elf->e_phentsize > parser->size)) {
+            fprintf(stderr, COLOR_RED "[!] Program header table extends beyond file bounds\n" COLOR_RESET);
+            elf->e_phnum = 0;
+        }
+        /* Validate string table index */
+        if (elf->e_shstrndx >= elf->e_shnum && elf->e_shnum > 0) {
+            fprintf(stderr, COLOR_RED "[!] Invalid section string table index\n" COLOR_RESET);
+            elf->e_shnum = 0;
+        }
+
         Elf32_Phdr* phdr = (Elf32_Phdr*) (data + elf->e_phoff);
         Elf32_Shdr* shdrs = (Elf32_Shdr*)(data + elf->e_shoff);
         dump_elf32hdr(elf);
@@ -560,7 +577,28 @@ bool print_meta_data(bparser* parser, void* arg)
             dump_elf32_phdr(elf, phdr, parser);
 
     } else if (bit_type == ELFCLASS64) {
+        if (parser->size < sizeof(Elf64_Ehdr)) {
+            fprintf(stderr, COLOR_RED "[!] File too small for 64-bit ELF header\n" COLOR_RESET);
+            return false;
+        }
         Elf64_Ehdr* elf = (Elf64_Ehdr*) data;
+
+        /* Validate section header table bounds */
+        if (elf->e_shoff > 0 && (elf->e_shoff + (size_t)elf->e_shnum * elf->e_shentsize > parser->size)) {
+            fprintf(stderr, COLOR_RED "[!] Section header table extends beyond file bounds\n" COLOR_RESET);
+            elf->e_shnum = 0;
+        }
+        /* Validate program header table bounds */
+        if (elf->e_phoff > 0 && (elf->e_phoff + (size_t)elf->e_phnum * elf->e_phentsize > parser->size)) {
+            fprintf(stderr, COLOR_RED "[!] Program header table extends beyond file bounds\n" COLOR_RESET);
+            elf->e_phnum = 0;
+        }
+        /* Validate string table index */
+        if (elf->e_shstrndx >= elf->e_shnum && elf->e_shnum > 0) {
+            fprintf(stderr, COLOR_RED "[!] Invalid section string table index\n" COLOR_RESET);
+            elf->e_shnum = 0;
+        }
+
         Elf64_Phdr* phdr = (Elf64_Phdr*) (data + elf->e_phoff);
         Elf64_Shdr* shdrs = (Elf64_Shdr*)(data + elf->e_shoff);
         dump_elf64hdr(elf);
@@ -575,7 +613,6 @@ bool print_meta_data(bparser* parser, void* arg)
         return false;
     }
 
-    // printf(COLOR_BLUE "=========================\n" COLOR_RESET);
     return true;
 }
 

--- a/modules/b_macho_metadata/b_macho_metadata.c
+++ b/modules/b_macho_metadata/b_macho_metadata.c
@@ -21,9 +21,11 @@
 #include "../bparser/bparser.h"
 #include "../../baseer.h"
 #include "../bx_macho_utils/bx_macho_utils.h"
+#include "../bx_elf_utils/bx_elf_utils.h"
 #include "../../utils/ui.h"
 #include <stdio.h>
 #include <string.h>
+#include <stdlib.h>
 
 /* =================== Validation helpers =================== */
 
@@ -85,6 +87,15 @@ static void handle_segment_64(const unsigned char *cmd_ptr, const unsigned char 
             if (sec_ptr + sizeof(section_64) > block + file_size) break;
             section_64 *sec = (section_64 *)sec_ptr;
             print_macho_section64_metadata(sec);
+
+            /* Print hex dump of section contents */
+            if (sec->size > 0 && sec->offset + sec->size <= file_size) {
+                unsigned char *data = (unsigned char *)(block + sec->offset);
+                int flags = macho_section_is_executable(sec->flags) ? SHF_EXECINSTR : 0;
+                unsigned char bit_type = 2; /* ELFCLASS64 = 2, used for 64-bit disasm mode */
+                print_body_bytes(data, sec->size, sec->addr, flags, bit_type);
+            }
+
             sec_ptr += sizeof(section_64);
         }
     }
@@ -102,6 +113,15 @@ static void handle_segment_32(const unsigned char *cmd_ptr, const unsigned char 
             if (sec_ptr + sizeof(section) > block + file_size) break;
             section *sec = (section *)sec_ptr;
             print_macho_section32_metadata(sec);
+
+            /* Print hex dump of section contents */
+            if (sec->size > 0 && sec->offset + sec->size <= file_size) {
+                unsigned char *data = (unsigned char *)(block + sec->offset);
+                int flags = macho_section_is_executable(sec->flags) ? SHF_EXECINSTR : 0;
+                unsigned char bit_type = 1; /* ELFCLASS32 = 1, used for 32-bit disasm mode */
+                print_body_bytes(data, sec->size, sec->addr, flags, bit_type);
+            }
+
             sec_ptr += sizeof(section);
         }
     }

--- a/modules/b_macho_metadata/b_macho_metadata.c
+++ b/modules/b_macho_metadata/b_macho_metadata.c
@@ -1,472 +1,436 @@
+/**
+ * @file b_macho_metadata.c
+ * @brief Mach-O metadata parser and pretty-printer.
+ *
+ * Parses and displays full metadata for Mach-O binaries including:
+ * - Header (magic, CPU type, file type, flags)
+ * - All load commands with detailed output
+ * - Segments and their sections
+ * - Symbol tables (LC_SYMTAB)
+ * - Dynamic symbol table summary (LC_DYSYMTAB)
+ * - Shared libraries (LC_LOAD_DYLIB)
+ * - Dynamic linker (LC_LOAD_DYLINKER)
+ * - Entry point (LC_MAIN)
+ * - UUID, build version, source version
+ * - Code signature and function starts info
+ * - Section hex dumps
+ *
+ * Supports both 32-bit and 64-bit Mach-O files with full input validation.
+ */
 #include "./b_macho_metadata.h"
-#include "../b_hashmap/b_hashmap.h"
 #include "../bparser/bparser.h"
 #include "../../baseer.h"
 #include "../bx_macho_utils/bx_macho_utils.h"
+#include "../../utils/ui.h"
+#include <stdio.h>
+#include <string.h>
 
-bool
-b_macho_metadata(bparser* parser, void* arg)
+/* =================== Validation helpers =================== */
+
+/**
+ * @brief Validate a Mach-O header's fields against the file size.
+ * @return true if the header appears sane, false otherwise.
+ */
+static bool validate_macho_header(const unsigned char *block, size_t file_size,
+                                  uint32_t ncmds, uint32_t sizeofcmds,
+                                  size_t header_size)
 {
-    unsigned char *block = (unsigned char*) parser->block;
-    mach_header *m_header = (mach_header*) block;
+    if (file_size < header_size) {
+        fprintf(stderr, COLOR_RED "[!] File too small for Mach-O header\n" COLOR_RESET);
+        return false;
+    }
+    if ((size_t)sizeofcmds + header_size > file_size) {
+        fprintf(stderr, COLOR_RED "[!] Load commands extend beyond file bounds "
+                "(header=%zu + cmds=%u > size=%zu)\n" COLOR_RESET,
+                header_size, sizeofcmds, file_size);
+        return false;
+    }
+    if (ncmds > 10000) {
+        fprintf(stderr, COLOR_RED "[!] Suspicious number of load commands: %u\n" COLOR_RESET, ncmds);
+        return false;
+    }
+    return true;
+}
 
-    if (m_header->magic == MH_MAGIC) {
-        mach_header *m_header = (mach_header*) block;
-        printf("32 bit mach-o binary file\n");
-        printf("Cpu Type: %d", m_header->cputype);             /* cpu specifier */
-        printf("cpusubtype: %d", m_header->cpusubtype);        /* machine specifier */
-        printf("filetype: %d", m_header->filetype);            /* type of file */
-        printf("ncmds: %d", m_header->ncmds);                  /* number of load commands */
-        printf("sizeofcmds: %d", m_header->sizeofcmds);        /* the size of all the load commands */
-        printf("flags: %d", m_header->flags);                  /* flags */
+/**
+ * @brief Check if a load command's size is valid.
+ */
+static bool validate_load_command(const load_command *lc, const unsigned char *cmd_ptr,
+                                  const unsigned char *end_ptr, uint32_t cmd_idx)
+{
+    if (lc->cmdsize < sizeof(load_command)) {
+        fprintf(stderr, COLOR_RED "[!] Load command %u has invalid size %u\n" COLOR_RESET,
+                cmd_idx, lc->cmdsize);
+        return false;
+    }
+    if (cmd_ptr + lc->cmdsize > end_ptr) {
+        fprintf(stderr, COLOR_RED "[!] Load command %u extends beyond file bounds\n" COLOR_RESET,
+                cmd_idx);
+        return false;
+    }
+    return true;
+}
 
-    } else if (m_header->magic == MH_MAGIC_64) {
-        mach_header_64 *m_header = (mach_header_64*) block;
+/* =================== Load command handlers =================== */
 
-        printf("================= Mach-O Header ====================\n");
-        printf(COLOR_GREEN "Class: " COLOR_RESET "64-bit\n");
-        printf(COLOR_GREEN "Cpu Type: " COLOR_RESET  "%d\n", m_header->cputype); /* cpu specifier */
-        printf(COLOR_GREEN "Machine: " COLOR_RESET "%d\n", m_header->cpusubtype);/* machine specifier */
-        printf(COLOR_GREEN "File Type: " COLOR_RESET "%s\n",  get_mach_o_type(m_header->filetype)); /* type of file */
-        printf(COLOR_GREEN "Number of load commands: " COLOR_RESET "%d\n", m_header->ncmds); /* number of load commands */
-        printf(COLOR_GREEN "Size of all the load commands: " COLOR_RESET "%d\n", m_header->sizeofcmds); /* the size of all the load commands */
-        printf(COLOR_GREEN"Flags: "COLOR_RESET"\n", m_header->flags);  /* flags */ 
-        print_mach_o_flags(m_header->flags);
-        printf(COLOR_GREEN"Reserved: "COLOR_RESET"%d\n", m_header->reserved); /* reserved */ 
-        printf("================= Load Commands ====================\n");
-        unsigned char *base_of_load_commands =  block + sizeof(mach_header_64);
-        // printf("%p\n", &block);
-        // printf("%p\n", &m_header);
-        // printf("%p\n", &base_of_load_commands);
+static void handle_segment_64(const unsigned char *cmd_ptr, const unsigned char *block,
+                              size_t file_size)
+{
+    segment_command_64 *seg = (segment_command_64 *)cmd_ptr;
+    print_macho_segment64_metadata(seg);
 
+    if (seg->nsects > 0) {
+        const unsigned char *sec_ptr = cmd_ptr + sizeof(segment_command_64);
+        for (uint32_t s = 0; s < seg->nsects; s++) {
+            if (sec_ptr + sizeof(section_64) > block + file_size) break;
+            section_64 *sec = (section_64 *)sec_ptr;
+            print_macho_section64_metadata(sec);
+            sec_ptr += sizeof(section_64);
+        }
+    }
+}
 
-        unsigned char *offset_of_load_command =  base_of_load_commands;
-        for (uint cmd_i =0; cmd_i< m_header->sizeofcmds;) {
-            load_command *command = (load_command*)offset_of_load_command;
-            // printf("Command: %d\n",command ->cmd);
-            print_load_command_info(command->cmd);
-            printf(COLOR_GREEN "Cmd Size:" COLOR_RESET " %d\n", command->cmdsize); 
+static void handle_segment_32(const unsigned char *cmd_ptr, const unsigned char *block,
+                              size_t file_size)
+{
+    segment_command *seg = (segment_command *)cmd_ptr;
+    print_macho_segment32_metadata(seg);
 
-            if(command->cmd == LC_SEGMENT_64) {
+    if (seg->nsects > 0) {
+        const unsigned char *sec_ptr = cmd_ptr + sizeof(segment_command);
+        for (uint32_t s = 0; s < seg->nsects; s++) {
+            if (sec_ptr + sizeof(section) > block + file_size) break;
+            section *sec = (section *)sec_ptr;
+            print_macho_section32_metadata(sec);
+            sec_ptr += sizeof(section);
+        }
+    }
+}
 
-                segment_command_64  *seg_cmd = (segment_command_64*)offset_of_load_command;
-                print_macho_segment64_metadata(seg_cmd);
-                unsigned char *seg_cmd_base = (unsigned char*) offset_of_load_command;
-                if(seg_cmd_base + seg_cmd->cmdsize >=  parser->block+parser->size) {
-                    puts("Out of bound attack detected\n");
-                    break;
-                }
+static void handle_symtab(const unsigned char *cmd_ptr, const unsigned char *block,
+                          size_t file_size, bool is_64bit)
+{
+    struct symtab_command *sym = (struct symtab_command *)cmd_ptr;
+    printf(COLOR_GREEN "    Symbol offset: " COLOR_RESET "0x%x\n", sym->symoff);
+    printf(COLOR_GREEN "    Num symbols:   " COLOR_RESET "%u\n", sym->nsyms);
+    printf(COLOR_GREEN "    String offset: " COLOR_RESET "0x%x\n", sym->stroff);
+    printf(COLOR_GREEN "    String size:   " COLOR_RESET "%u bytes\n", sym->strsize);
 
-                printf("\n");
-                if(seg_cmd->nsects > 0) {
-                    printf(COLOR_BLUE "Sections:\n" COLOR_RESET);
-                    for(unsigned char* sec = seg_cmd_base + sizeof(segment_command_64); sec < seg_cmd_base + seg_cmd->cmdsize;
-                                                           sec += sizeof(section_64)) { 
-                        section_64* sec_cmd = (section_64*) sec;
-                        print_macho_section64_metadata(sec_cmd);
-                        printf("\n");
-                    }
-                    printf("\n");
-                }
+    if (is_64bit)
+        print_macho_symbols_64(block, file_size, sym->symoff, sym->nsyms, sym->stroff, sym->strsize);
+    else
+        print_macho_symbols_32(block, file_size, sym->symoff, sym->nsyms, sym->stroff, sym->strsize);
+}
 
-            } else if(command->cmd == LC_DYLD_CHAINED_FIXUPS) {
-                /*
-                 * The linkedit_data_command contains the offsets and sizes of a blob
-                 * of data in the __LINKEDIT segment.  
-                 */
-                // print_linkedit_data_command_metadata()
-                linkedit_data_command *led_cmd = (linkedit_data_command*)offset_of_load_command;
-                printf(COLOR_GREEN "  Data offset:" COLOR_RESET " 0x%x\n", led_cmd->dataoff); 
-                printf(COLOR_GREEN "  Data size:" COLOR_RESET " %d\n", led_cmd->datasize); 
-                // struct linkedit_data_command {
-                //     uint32_t	cmd;		/* LC_CODE_SIGNATURE, LC_SEGMENT_SPLIT_INFO,
-                //                                    LC_FUNCTION_STARTS, LC_DATA_IN_CODE,
-                //                                    LC_DYLIB_CODE_SIGN_DRS,
-                //                                    LC_LINKER_OPTIMIZATION_HINT,
-                //                                    LC_DYLD_EXPORTS_TRIE, or
-                //                                    LC_DYLD_CHAINED_FIXUPS. */
-                //     uint32_t	cmdsize;	/* sizeof(struct linkedit_data_command) */
-                //     uint32_t	dataoff;	/* file offset of data in __LINKEDIT segment */
-                //     uint32_t	datasize;	/* file size of data in __LINKEDIT segment  */
-                // };
+static void handle_dysymtab(const unsigned char *cmd_ptr)
+{
+    struct dysymtab_command *dys = (struct dysymtab_command *)cmd_ptr;
+    printf(COLOR_GREEN "    Local symbols:      " COLOR_RESET "%u (index %u)\n", dys->nlocalsym, dys->ilocalsym);
+    printf(COLOR_GREEN "    External symbols:   " COLOR_RESET "%u (index %u)\n", dys->nextdefsym, dys->iextdefsym);
+    printf(COLOR_GREEN "    Undefined symbols:  " COLOR_RESET "%u (index %u)\n", dys->nundefsym, dys->iundefsym);
+    if (dys->nindirectsyms > 0)
+        printf(COLOR_GREEN "    Indirect symbols:   " COLOR_RESET "%u (offset 0x%x)\n", dys->nindirectsyms, dys->indirectsymoff);
+    if (dys->nextrel > 0)
+        printf(COLOR_GREEN "    External relocs:    " COLOR_RESET "%u (offset 0x%x)\n", dys->nextrel, dys->extreloff);
+    if (dys->nlocrel > 0)
+        printf(COLOR_GREEN "    Local relocs:       " COLOR_RESET "%u (offset 0x%x)\n", dys->nlocrel, dys->locreloff);
+}
 
-            } else if (command->cmd == LC_DYLD_EXPORTS_TRIE) {
-                linkedit_data_command *led_cmd = (linkedit_data_command*)offset_of_load_command;
-                printf(COLOR_GREEN "  Data offset:" COLOR_RESET " 0x%x\n", led_cmd->dataoff); 
-                printf(COLOR_GREEN "  Data size:" COLOR_RESET " %d\n", led_cmd->datasize); 
-            } else if(command->cmd == LC_SYMTAB) {
+static void handle_dylib(const unsigned char *cmd_ptr, uint32_t cmdsize)
+{
+    dylib_command *dl = (dylib_command *)cmd_ptr;
+    uint32_t name_off = dl->dylib.name_offset;
 
-                /*
-                 * The symtab_command contains the offsets and sizes of the link-edit 4.3BSD
-                 * "stab" style symbol table information as described in the header files
-                 * <nlist.h> and <stab.h>.
-                 */
-                // struct symtab_command {
-                //     uint32_t	cmd;		/* LC_SYMTAB */
-                //     uint32_t	cmdsize;	/* sizeof(struct symtab_command) */
-                //     uint32_t	symoff;		/* symbol table offset */
-                //     uint32_t	nsyms;		/* number of symbol table entries */
-                //     uint32_t	stroff;		/* string table offset */
-                //     uint32_t	strsize;	/* string table size in bytes */
-                // };
+    const char *name = "(invalid offset)";
+    if (name_off < cmdsize)
+        name = (const char *)cmd_ptr + name_off;
 
+    printf(COLOR_GREEN "    Library:       " COLOR_RESET "%s\n", name);
+    printf(COLOR_GREEN "    Version:       " COLOR_RESET);
+    print_version_xyz(dl->dylib.current_version);
+    printf("\n");
+    printf(COLOR_GREEN "    Compat:        " COLOR_RESET);
+    print_version_xyz(dl->dylib.compatibility_version);
+    printf("\n");
+}
 
-            } else if(command->cmd == LC_DYSYMTAB) {
+static void handle_dylinker(const unsigned char *cmd_ptr, uint32_t cmdsize)
+{
+    dylinker_command *dl = (dylinker_command *)cmd_ptr;
+    uint32_t name_off = dl->name_offset;
 
-                /*
-                 * This is the second set of the symbolic information which is used to support
-                 * the data structures for the dynamically link editor.
-                 *
-                 * The original set of symbolic information in the symtab_command which contains
-                 * the symbol and string tables must also be present when this load command is
-                 * present.  When this load command is present the symbol table is organized
-                 * into three groups of symbols:
-                 *	local symbols (static and debugging symbols) - grouped by module
-                 *	defined external symbols - grouped by module (sorted by name if not lib)
-                 *	undefined external symbols (sorted by name if MH_BINDATLOAD is not set,
-                 *	     			    and in order the were seen by the static
-                 *				    linker if MH_BINDATLOAD is set)
-                 * In this load command there are offsets and counts to each of the three groups
-                 * of symbols.
-                 *
-                 * This load command contains a the offsets and sizes of the following new
-                 * symbolic information tables:
-                 *	table of contents
-                 *	module table
-                 *	reference symbol table
-                 *	indirect symbol table
-                 * The first three tables above (the table of contents, module table and
-                 * reference symbol table) are only present if the file is a dynamically linked
-                 * shared library.  For executable and object modules, which are files
-                 * containing only one module, the information that would be in these three
-                 * tables is determined as follows:
-                 * 	table of contents - the defined external symbols are sorted by name
-                 *	module table - the file contains only one module so everything in the
-                 *		       file is part of the module.
-                 *	reference symbol table - is the defined and undefined external symbols
-                 *
-                 * For dynamically linked shared library files this load command also contains
-                 * offsets and sizes to the pool of relocation entries for all sections
-                 * separated into two groups:
-                 *	external relocation entries
-                 *	local relocation entries
-                 * For executable and object modules the relocation entries continue to hang
-                 * off the section structures.
-                 */
-                // struct dysymtab_command {
-                //     uint32_t cmd;	/* LC_DYSYMTAB */
-                //     uint32_t cmdsize;	/* sizeof(struct dysymtab_command) */
-                //     /*
-                //      * The symbols indicated by symoff and nsyms of the LC_SYMTAB load command
-                //      * are grouped into the following three groups:
-                //      *    local symbols (further grouped by the module they are from)
-                //      *    defined external symbols (further grouped by the module they are from)
-                //      *    undefined symbols
-                //      *
-                //      * The local symbols are used only for debugging.  The dynamic binding
-                //      * process may have to use them to indicate to the debugger the local
-                //      * symbols for a module that is being bound.
-                //      *
-                //      * The last two groups are used by the dynamic binding process to do the
-                //      * binding (indirectly through the module table and the reference symbol
-                //      * table when this is a dynamically linked shared library file).
-                //      */
-                //     uint32_t ilocalsym;	/* index to local symbols */
-                //     uint32_t nlocalsym;	/* number of local symbols */
-                //     uint32_t iextdefsym;/* index to externally defined symbols */
-                //     uint32_t nextdefsym;/* number of externally defined symbols */
-                //     uint32_t iundefsym;	/* index to undefined symbols */
-                //     uint32_t nundefsym;	/* number of undefined symbols */
-                //     /*
-                //      * For the for the dynamic binding process to find which module a symbol
-                //      * is defined in the table of contents is used (analogous to the ranlib
-                //      * structure in an archive) which maps defined external symbols to modules
-                //      * they are defined in.  This exists only in a dynamically linked shared
-                //      * library file.  For executable and object modules the defined external
-                //      * symbols are sorted by name and is use as the table of contents.
-                //      */
-                //     uint32_t tocoff;	/* file offset to table of contents */
-                //     uint32_t ntoc;	/* number of entries in table of contents */
-                //     /*
-                //      * To support dynamic binding of "modules" (whole object files) the symbol
-                //      * table must reflect the modules that the file was created from.  This is
-                //      * done by having a module table that has indexes and counts into the merged
-                //      * tables for each module.  The module structure that these two entries
-                //      * refer to is described below.  This exists only in a dynamically linked
-                //      * shared library file.  For executable and object modules the file only
-                //      * contains one module so everything in the file belongs to the module.
-                //      */
-                //     uint32_t modtaboff;	/* file offset to module table */
-                //     uint32_t nmodtab;	/* number of module table entries */
-                //     /*
-                //      * To support dynamic module binding the module structure for each module
-                //      * indicates the external references (defined and undefined) each module
-                //      * makes.  For each module there is an offset and a count into the
-                //      * reference symbol table for the symbols that the module references.
-                //      * This exists only in a dynamically linked shared library file.  For
-                //      * executable and object modules the defined external symbols and the
-                //      * undefined external symbols indicates the external references.
-                //      */
-                //     uint32_t extrefsymoff;	/* offset to referenced symbol table */
-                //     uint32_t nextrefsyms;	/* number of referenced symbol table entries */
-                //     /*
-                //      * The sections that contain "symbol pointers" and "routine stubs" have
-                //      * indexes and (implied counts based on the size of the section and fixed
-                //      * size of the entry) into the "indirect symbol" table for each pointer
-                //      * and stub.  For every section of these two types the index into the
-                //      * indirect symbol table is stored in the section header in the field
-                //      * reserved1.  An indirect symbol table entry is simply a 32bit index into
-                //      * the symbol table to the symbol that the pointer or stub is referring to.
-                //      * The indirect symbol table is ordered to match the entries in the section.
-                //      */
-                //     uint32_t indirectsymoff; /* file offset to the indirect symbol table */
-                //     uint32_t nindirectsyms;  /* number of indirect symbol table entries */
-                //     /*
-                //      * To support relocating an individual module in a library file quickly the
-                //      * external relocation entries for each module in the library need to be
-                //      * accessed efficiently.  Since the relocation entries can't be accessed
-                //      * through the section headers for a library file they are separated into
-                //      * groups of local and external entries further grouped by module.  In this
-                //      * case the presents of this load command who's extreloff, nextrel,
-                //      * locreloff and nlocrel fields are non-zero indicates that the relocation
-                //      * entries of non-merged sections are not referenced through the section
-                //      * structures (and the reloff and nreloc fields in the section headers are
-                //      * set to zero).
-                //      *
-                //      * Since the relocation entries are not accessed through the section headers
-                //      * this requires the r_address field to be something other than a section
-                //      * offset to identify the item to be relocated.  In this case r_address is
-                //      * set to the offset from the vmaddr of the first LC_SEGMENT command.
-                //      * For MH_SPLIT_SEGS images r_address is set to the the offset from the
-                //      * vmaddr of the first read-write LC_SEGMENT command.
-                //      *
-                //      * The relocation entries are grouped by module and the module table
-                //      * entries have indexes and counts into them for the group of external
-                //      * relocation entries for that the module.
-                //      *
-                //      * For sections that are merged across modules there must not be any
-                //      * remaining external relocation entries for them (for merged sections
-                //      * remaining relocation entries must be local).
-                //      */
-                //     uint32_t extreloff;	/* offset to external relocation entries */
-                //     uint32_t nextrel;	/* number of external relocation entries */
-                //     /*
-                //      * All the local relocation entries are grouped together (they are not
-                //      * grouped by their module since they are only used if the object is moved
-                //      * from it staticly link edited address).
-                //      */
-                //     uint32_t locreloff;	/* offset to local relocation entries */
-                //     uint32_t nlocrel;	/* number of local relocation entries */
-                // };
+    const char *name = "(invalid offset)";
+    if (name_off < cmdsize)
+        name = (const char *)cmd_ptr + name_off;
 
+    printf(COLOR_GREEN "    Dynamic Linker: " COLOR_RESET "%s\n", name);
+}
 
-            // } else if(command->cmd == LC_LOAD_DYLINKER) {
-            } else if(command->cmd == LC_ID_DYLINKER || command->cmd ==  LC_LOAD_DYLINKER || command->cmd == LC_DYLD_ENVIRONMENT  ) {
-                dylinker_command *dyld_cmd = (dylinker_command*)offset_of_load_command;
-                printf("====================hello\n");
-                // printf(COLOR_GREEN "  " COLOR_RESET " %s\n", dyld_cmd->name);
-                /*
-                 * A program that uses a dynamic linker contains a dylinker_command to identify
-                 * the name of the dynamic linker (LC_LOAD_DYLINKER).  And a dynamic linker
-                 * contains a dylinker_command to identify the dynamic linker (LC_ID_DYLINKER).
-                 * A file can have at most one of these.
-                 * This struct is also used for the LC_DYLD_ENVIRONMENT load command and
-                 * contains string for dyld to treat like environment variable.
-                 */
-                // struct dylinker_command {
-                //     uint32_t	cmd;		/* LC_ID_DYLINKER, LC_LOAD_DYLINKER or
-                //                                    LC_DYLD_ENVIRONMENT */
-                //     uint32_t	cmdsize;	/* includes pathname string */
-                //     union lc_str    name;		/* dynamic linker's path name */
-                // };
+static void handle_uuid(const unsigned char *cmd_ptr)
+{
+    uuid_command *uc = (uuid_command *)cmd_ptr;
+    printf(COLOR_GREEN "    UUID: " COLOR_RESET);
+    print_uuid(uc->uuid);
+    printf("\n");
+}
 
+static void handle_main(const unsigned char *cmd_ptr)
+{
+    entry_point_command *ep = (entry_point_command *)cmd_ptr;
+    printf(COLOR_GREEN "    Entry offset:  " COLOR_RESET "0x%lx\n", (unsigned long)ep->entryoff);
+    if (ep->stacksize > 0)
+        printf(COLOR_GREEN "    Stack size:    " COLOR_RESET "0x%lx\n", (unsigned long)ep->stacksize);
+}
 
-            } else if(command->cmd == LC_UUID) {
+static void handle_build_version(const unsigned char *cmd_ptr)
+{
+    build_version_command *bv = (build_version_command *)cmd_ptr;
+    printf(COLOR_GREEN "    Platform:      " COLOR_RESET "%s\n", platform_to_string(bv->platform));
+    printf(COLOR_GREEN "    Min OS:        " COLOR_RESET);
+    print_tool_version(bv->minos); printf("\n");
+    printf(COLOR_GREEN "    SDK:           " COLOR_RESET);
+    print_tool_version(bv->sdk); printf("\n");
 
-                /*
-                 * The uuid load command contains a single 128-bit unique random number that
-                 * identifies an object produced by the static link editor.
-                 */
-                // struct uuid_command {
-                //     uint32_t	cmd;		/* LC_UUID */
-                //     uint32_t	cmdsize;	/* sizeof(struct uuid_command) */
-                //     uint8_t	uuid[16];	/* the 128-bit uuid */
-                // };
-
-                uuid_command *uuid_cmd = (uuid_command*)offset_of_load_command;
-                printf(COLOR_GREEN"UUID: "COLOR_RESET);
-                print_uuid(uuid_cmd->uuid);
-                printf("\n");
-
-            } else if(command->cmd == LC_BUILD_VERSION) {
-
-                /*
-                 * The build_version_command contains the min OS version on which this
-                 * binary was built to run for its platform.  The list of known platforms and
-                 * tool values following it.
-                 */
-                // struct build_version_command {
-                //     uint32_t	cmd;		/* LC_BUILD_VERSION */
-                //     uint32_t	cmdsize;	/* sizeof(struct build_version_command) plus */
-                //     /* ntools * sizeof(struct build_tool_version) */
-                //     uint32_t	platform;	/* platform */
-                //     uint32_t	minos;		/* X.Y.Z is encoded in nibbles xxxx.yy.zz */
-                //     uint32_t	sdk;		/* X.Y.Z is encoded in nibbles xxxx.yy.zz */
-                //     uint32_t	ntools;		/* number of tool entries following this */
-                // };
-                //
-                //typedef struct build_tool_version {
-                // uint32_t	tool;		/* enum for the tool */
-                // uint32_t	version;	/* version number of the tool */
-                // } build_tool_version ;
-
-                void *build_v_cmd_tools_ptr = (void*)offset_of_load_command + sizeof(build_version_command);
-                build_version_command *build_v_cmd = (build_version_command*)offset_of_load_command;
-
-                printf(COLOR_GREEN "Platform: " COLOR_RESET "%s\n", platform_to_string(build_v_cmd->platform));
-                printf(COLOR_GREEN "Min OS: " COLOR_RESET); print_tool_version(build_v_cmd->minos); printf("\n");
-                printf(COLOR_GREEN "SDK: " COLOR_RESET); print_tool_version(build_v_cmd->sdk); printf("\n");
-
-                if (build_v_cmd -> ntools > 0) {
-                    build_tool_version *tools = (build_tool_version *)build_v_cmd_tools_ptr;
-                    for (int i = 0; i < build_v_cmd -> ntools; i++) {
-                        printf(COLOR_GREEN "Tool: " COLOR_RESET "%s, "COLOR_GREEN"Version: " COLOR_RESET, tool_to_string(tools[i].tool));
-                        print_tool_version(tools[i].version);
-                        printf("\n");
-                    }
-                }
-
-            } else if(command->cmd == LC_SOURCE_VERSION) {
-
-                /*
-                 * The source_version_command is an optional load command containing
-                 * the version of the sources used to build the binary.
-                 */
-                // struct source_version_command {
-                //     uint32_t  cmd;	/* LC_SOURCE_VERSION */
-                //     uint32_t  cmdsize;	/* 16 */
-                //     uint64_t  version;	/* A.B.C.D.E packed as a24.b10.c10.d10.e10 */
-                // };
-                source_version_command * svc = (source_version_command *) offset_of_load_command;
-                
-                //
-                printf(COLOR_GREEN "Version: " COLOR_RESET);
-                print_source_version(svc->version);
-                printf("\n");
-                // printf(COLOR_GREEN "version: " COLOR_RESET "%s\n", svc->version) ;
-
-
-            } else if(command->cmd == LC_MAIN) {
-
-
-                /*
-                 * The entry_point_command is a replacement for thread_command.
-                 * It is used for main executables to specify the location (file offset)
-                 * of main().  If -stack_size was used at link time, the stacksize
-                 * field will contain the stack size need for the main thread.
-                 */
-                // struct entry_point_command {
-                //     uint32_t  cmd;	/* LC_MAIN only used in MH_EXECUTE filetypes */
-                //     uint32_t  cmdsize;	/* 24 */
-                //     uint64_t  entryoff;	/* file (__TEXT) offset of main() */
-                //     uint64_t  stacksize;/* if not zero, initial stack size */
-                // };
-                
-                entry_point_command* epc = (entry_point_command*) offset_of_load_command;
-                printf(COLOR_GREEN "Entry offset: " COLOR_RESET "0x%08lx\n", epc->entryoff );
-                printf(COLOR_GREEN "Stack size: " COLOR_RESET "0x%ld\n", epc->stacksize);
-
-            } else if(command->cmd == LC_LOAD_DYLIB) {
-
-                /*
-                 * A dynamically linked shared library (filetype == MH_DYLIB in the mach header)
-                 * contains a dylib_command (cmd == LC_ID_DYLIB) to identify the library.
-                 * An object that uses a dynamically linked shared library also contains a
-                 * dylib_command (cmd == LC_LOAD_DYLIB, LC_LOAD_WEAK_DYLIB, or
-                 * LC_REEXPORT_DYLIB) for each library it uses.
-                 */
-                // struct dylib_command {
-                //     uint32_t	cmd;		/* LC_ID_DYLIB, LC_LOAD_{,WEAK_}DYLIB,
-                //                                    LC_REEXPORT_DYLIB */
-                //     uint32_t	cmdsize;	/* includes pathname string */
-                //     struct dylib	dylib;		/* the library identification */
-                // };
-                //
-
-                dylib_command *dylib_cmd = (dylib_command *) offset_of_load_command;
-                // struct dylib dylib = &dylib_cmd->dylib;
-                // printf("dylib: %s\n", dylib->name);
-                // printf("%d\n", dylib.current_version);
-                // printf("%d\n", dylib.compatibility_version);
-                // printf("%d\n", dylib.timestamp);
-
-
-
-
-            } else if(command->cmd == LC_FUNCTION_STARTS) {
-
-                /*
-                 * The linkedit_data_command contains the offsets and sizes of a blob
-                 * of data in the __LINKEDIT segment.  
-                 */
-                // struct linkedit_data_command {
-                //     uint32_t	cmd;		/* LC_CODE_SIGNATURE, LC_SEGMENT_SPLIT_INFO,
-                //                                    LC_FUNCTION_STARTS, LC_DATA_IN_CODE,
-                //                                    LC_DYLIB_CODE_SIGN_DRS,
-                //                                    LC_LINKER_OPTIMIZATION_HINT,
-                //                                    LC_DYLD_EXPORTS_TRIE, or
-                //                                    LC_DYLD_CHAINED_FIXUPS. */
-                //     uint32_t	cmdsize;	/* sizeof(struct linkedit_data_command) */
-                //     uint32_t	dataoff;	/* file offset of data in __LINKEDIT segment */
-                //     uint32_t	datasize;	/* file size of data in __LINKEDIT segment  */
-                // };
-
-
-            } else if(command->cmd == LC_DATA_IN_CODE) {
-
-                /*
-                 * The LC_DATA_IN_CODE load commands uses a linkedit_data_command 
-                 * to point to an array of data_in_code_entry entries. Each entry
-                 * describes a range of data in a code section.
-                 */
-                // struct data_in_code_entry {
-                //     uint32_t	offset;  /* from mach_header to start of data range*/
-                //     uint16_t	length;  /* number of bytes in data range */
-                //     uint16_t	kind;    /* a DICE_KIND_* value  */
-                // };
-
-            } else if(command->cmd == LC_CODE_SIGNATURE) {
-                
-                // /*
-                //  * The linkedit_data_command contains the offsets and sizes of a blob
-                //  * of data in the __LINKEDIT segment.  
-                //  */
-                // struct linkedit_data_command {
-                //     uint32_t	cmd;		/* LC_CODE_SIGNATURE, LC_SEGMENT_SPLIT_INFO,
-                //                                    LC_FUNCTION_STARTS, LC_DATA_IN_CODE,
-                // 				   LC_DYLIB_CODE_SIGN_DRS,
-                // 				   LC_LINKER_OPTIMIZATION_HINT,
-                // 				   LC_DYLD_EXPORTS_TRIE, or
-                // 				   LC_DYLD_CHAINED_FIXUPS. */
-                //     uint32_t	cmdsize;	/* sizeof(struct linkedit_data_command) */
-                //     uint32_t	dataoff;	/* file offset of data in __LINKEDIT segment */
-                //     uint32_t	datasize;	/* file size of data in __LINKEDIT segment  */
-                // };
-
-            }
+    if (bv->ntools > 0) {
+        build_tool_version *tools = (build_tool_version *)(cmd_ptr + sizeof(build_version_command));
+        for (uint32_t i = 0; i < bv->ntools; i++) {
+            printf(COLOR_GREEN "    Tool:          " COLOR_RESET "%s ", tool_to_string(tools[i].tool));
+            print_tool_version(tools[i].version);
             printf("\n");
+        }
+    }
+}
 
-            cmd_i += command->cmdsize;
-            offset_of_load_command += command->cmdsize;
-        } 
+static void handle_source_version(const unsigned char *cmd_ptr)
+{
+    source_version_command *sv = (source_version_command *)cmd_ptr;
+    printf(COLOR_GREEN "    Version:       " COLOR_RESET);
+    print_source_version(sv->version);
+    printf("\n");
+}
 
+static void handle_linkedit_data(const unsigned char *cmd_ptr)
+{
+    linkedit_data_command *led = (linkedit_data_command *)cmd_ptr;
+    printf(COLOR_GREEN "    Data offset:   " COLOR_RESET "0x%x\n", led->dataoff);
+    printf(COLOR_GREEN "    Data size:     " COLOR_RESET "%u bytes\n", led->datasize);
+}
 
-        printf("================= DATA ====================\n");
+/* =================== Main metadata function =================== */
 
+/**
+ * @brief Parse and print metadata for a 64-bit Mach-O file.
+ */
+static bool parse_macho_64(const unsigned char *block, size_t file_size)
+{
+    mach_header_64 *hdr = (mach_header_64 *)block;
 
-    } else {
+    if (!validate_macho_header(block, file_size, hdr->ncmds, hdr->sizeofcmds,
+                               sizeof(mach_header_64)))
+        return false;
+
+    /* Print header */
+    printf(COLOR_BLUE "================= Mach-O Header ====================\n" COLOR_RESET);
+    printf(COLOR_GREEN "Class:             " COLOR_RESET "64-bit\n");
+    printf(COLOR_GREEN "CPU Type:          " COLOR_RESET "%s\n", cpu_type_to_string(hdr->cputype));
+    printf(COLOR_GREEN "CPU Subtype:       " COLOR_RESET "%s\n", cpu_subtype_to_string(hdr->cputype, hdr->cpusubtype));
+    printf(COLOR_GREEN "File Type:         " COLOR_RESET "%s\n", get_mach_o_type(hdr->filetype));
+    printf(COLOR_GREEN "Load Commands:     " COLOR_RESET "%u (%u bytes)\n", hdr->ncmds, hdr->sizeofcmds);
+    printf(COLOR_GREEN "Flags:             " COLOR_RESET "0x%08x\n", hdr->flags);
+    print_mach_o_flags(hdr->flags);
+    printf(COLOR_GREEN "Reserved:          " COLOR_RESET "0x%x\n", hdr->reserved);
+
+    /* Iterate load commands */
+    printf(COLOR_BLUE "\n================= Load Commands (%u) ====================\n" COLOR_RESET,
+           hdr->ncmds);
+
+    const unsigned char *cmd_ptr = block + sizeof(mach_header_64);
+    const unsigned char *end_ptr = block + file_size;
+
+    for (uint32_t i = 0; i < hdr->ncmds; i++) {
+        if (cmd_ptr + sizeof(load_command) > end_ptr) break;
+        load_command *lc = (load_command *)cmd_ptr;
+
+        if (!validate_load_command(lc, cmd_ptr, end_ptr, i)) break;
+
+        printf("\n" COLOR_BLUE "[%u/%u] " COLOR_RESET, i + 1, hdr->ncmds);
+        print_load_command_info(lc->cmd);
+        printf(COLOR_GREEN "    Cmd Size:      " COLOR_RESET "%u bytes\n", lc->cmdsize);
+
+        switch (lc->cmd) {
+            case LC_SEGMENT_64:
+                handle_segment_64(cmd_ptr, block, file_size);
+                break;
+            case LC_SYMTAB:
+                handle_symtab(cmd_ptr, block, file_size, true);
+                break;
+            case LC_DYSYMTAB:
+                handle_dysymtab(cmd_ptr);
+                break;
+            case LC_LOAD_DYLIB:
+            case LC_LOAD_WEAK_DYLIB:
+            case LC_REEXPORT_DYLIB:
+            case LC_LAZY_LOAD_DYLIB:
+            case LC_ID_DYLIB:
+                handle_dylib(cmd_ptr, lc->cmdsize);
+                break;
+            case LC_LOAD_DYLINKER:
+            case LC_ID_DYLINKER:
+            case LC_DYLD_ENVIRONMENT:
+                handle_dylinker(cmd_ptr, lc->cmdsize);
+                break;
+            case LC_UUID:
+                handle_uuid(cmd_ptr);
+                break;
+            case LC_MAIN:
+                handle_main(cmd_ptr);
+                break;
+            case LC_BUILD_VERSION:
+                handle_build_version(cmd_ptr);
+                break;
+            case LC_SOURCE_VERSION:
+                handle_source_version(cmd_ptr);
+                break;
+            case LC_CODE_SIGNATURE:
+            case LC_FUNCTION_STARTS:
+            case LC_DATA_IN_CODE:
+            case LC_DYLD_EXPORTS_TRIE:
+            case LC_DYLD_CHAINED_FIXUPS:
+            case LC_SEGMENT_SPLIT_INFO:
+            case LC_DYLIB_CODE_SIGN_DRS:
+            case LC_LINKER_OPTIMIZATION_HINT:
+                handle_linkedit_data(cmd_ptr);
+                break;
+            case LC_RPATH: {
+                /* rpath_command has name offset at byte 8 */
+                uint32_t off = *(uint32_t *)(cmd_ptr + 8);
+                if (off < lc->cmdsize)
+                    printf(COLOR_GREEN "    Path:          " COLOR_RESET "%s\n", (const char*)cmd_ptr + off);
+                break;
+            }
+            default:
+                break;
+        }
+
+        cmd_ptr += lc->cmdsize;
+    }
+
+    printf("\n");
+    return true;
+}
+
+/**
+ * @brief Parse and print metadata for a 32-bit Mach-O file.
+ */
+static bool parse_macho_32(const unsigned char *block, size_t file_size)
+{
+    mach_header *hdr = (mach_header *)block;
+
+    if (!validate_macho_header(block, file_size, hdr->ncmds, hdr->sizeofcmds,
+                               sizeof(mach_header)))
+        return false;
+
+    /* Print header */
+    printf(COLOR_BLUE "================= Mach-O Header ====================\n" COLOR_RESET);
+    printf(COLOR_GREEN "Class:             " COLOR_RESET "32-bit\n");
+    printf(COLOR_GREEN "CPU Type:          " COLOR_RESET "%s\n", cpu_type_to_string(hdr->cputype));
+    printf(COLOR_GREEN "CPU Subtype:       " COLOR_RESET "%s\n", cpu_subtype_to_string(hdr->cputype, hdr->cpusubtype));
+    printf(COLOR_GREEN "File Type:         " COLOR_RESET "%s\n", get_mach_o_type(hdr->filetype));
+    printf(COLOR_GREEN "Load Commands:     " COLOR_RESET "%u (%u bytes)\n", hdr->ncmds, hdr->sizeofcmds);
+    printf(COLOR_GREEN "Flags:             " COLOR_RESET "0x%08x\n", hdr->flags);
+    print_mach_o_flags(hdr->flags);
+
+    /* Iterate load commands */
+    printf(COLOR_BLUE "\n================= Load Commands (%u) ====================\n" COLOR_RESET,
+           hdr->ncmds);
+
+    const unsigned char *cmd_ptr = block + sizeof(mach_header);
+    const unsigned char *end_ptr = block + file_size;
+
+    for (uint32_t i = 0; i < hdr->ncmds; i++) {
+        if (cmd_ptr + sizeof(load_command) > end_ptr) break;
+        load_command *lc = (load_command *)cmd_ptr;
+
+        if (!validate_load_command(lc, cmd_ptr, end_ptr, i)) break;
+
+        printf("\n" COLOR_BLUE "[%u/%u] " COLOR_RESET, i + 1, hdr->ncmds);
+        print_load_command_info(lc->cmd);
+        printf(COLOR_GREEN "    Cmd Size:      " COLOR_RESET "%u bytes\n", lc->cmdsize);
+
+        switch (lc->cmd) {
+            case LC_SEGMENT:
+                handle_segment_32(cmd_ptr, block, file_size);
+                break;
+            case LC_SYMTAB:
+                handle_symtab(cmd_ptr, block, file_size, false);
+                break;
+            case LC_DYSYMTAB:
+                handle_dysymtab(cmd_ptr);
+                break;
+            case LC_LOAD_DYLIB:
+            case LC_LOAD_WEAK_DYLIB:
+            case LC_REEXPORT_DYLIB:
+            case LC_LAZY_LOAD_DYLIB:
+            case LC_ID_DYLIB:
+                handle_dylib(cmd_ptr, lc->cmdsize);
+                break;
+            case LC_LOAD_DYLINKER:
+            case LC_ID_DYLINKER:
+            case LC_DYLD_ENVIRONMENT:
+                handle_dylinker(cmd_ptr, lc->cmdsize);
+                break;
+            case LC_UUID:
+                handle_uuid(cmd_ptr);
+                break;
+            case LC_BUILD_VERSION:
+                handle_build_version(cmd_ptr);
+                break;
+            case LC_SOURCE_VERSION:
+                handle_source_version(cmd_ptr);
+                break;
+            case LC_CODE_SIGNATURE:
+            case LC_FUNCTION_STARTS:
+            case LC_DATA_IN_CODE:
+            case LC_DYLD_EXPORTS_TRIE:
+            case LC_DYLD_CHAINED_FIXUPS:
+                handle_linkedit_data(cmd_ptr);
+                break;
+            default:
+                break;
+        }
+
+        cmd_ptr += lc->cmdsize;
+    }
+
+    printf("\n");
+    return true;
+}
+
+/* =================== Public entry point =================== */
+
+bool b_macho_metadata(bparser *parser, void *arg)
+{
+    if (!parser || !parser->block) {
+        fprintf(stderr, COLOR_RED "[!] Invalid parser state\n" COLOR_RESET);
         return false;
     }
 
-    return true;
+    const unsigned char *block = (const unsigned char *)parser->block;
+    size_t file_size = parser->size;
+
+    if (file_size < sizeof(uint32_t)) {
+        fprintf(stderr, COLOR_RED "[!] File too small to be a Mach-O binary\n" COLOR_RESET);
+        return false;
+    }
+
+    uint32_t magic = *(const uint32_t *)block;
+
+    if (magic == MH_MAGIC_64) {
+        return parse_macho_64(block, file_size);
+    } else if (magic == MH_MAGIC) {
+        return parse_macho_32(block, file_size);
+    } else {
+        fprintf(stderr, COLOR_RED "[!] Unknown Mach-O magic: 0x%08x\n" COLOR_RESET, magic);
+        return false;
+    }
 }

--- a/modules/binhead/bx_binhead.c
+++ b/modules/binhead/bx_binhead.c
@@ -64,23 +64,16 @@ unsigned long NXSwapLong(unsigned long inv)
 bool bx_binhead(baseer_target_t *target, void *arg)
 {   
 
-    // printf("This is from binhead: %p\n", ((inputs*)arg));
     if (target == NULL || target->block == NULL)
         return false;
 
-    bparser* bp = NULL;
-    // printf("%d\n", target->size);
-    bp = bparser_load(target);
+    bparser* bp = bparser_load(target);
 
     bmagic magics[] = {
         {"ELF", ELF_MAGIC, reverse_bytes(ELF_MAGIC), bx_elf, 0},
         {"TAR", TAR_MAGIC, reverse_bytes(TAR_MAGIC), bx_tar, 257},
         {"Mach-o", MH_MAGIC, NXSwapInt(MH_MAGIC), bx_macho, 0},
         {"Mach-o", MH_MAGIC_64, NXSwapInt(MH_MAGIC_64), bx_macho, 0},
-        // {"PDF", PDF_MAGIC, reverse_bytes(PDF_MAGIC), NULL, 0},
-        // {"PNG", PNG_MAGIC, reverse_bytes(PNG_MAGIC), NULL, 0},
-        // {"ZIP", ZIP_MAGIC, reverse_bytes(ZIP_MAGIC), NULL, 0},
-        // { NULL, 0,         0,                 NULL }
     };
 
 

--- a/modules/bparser/bparser.c
+++ b/modules/bparser/bparser.c
@@ -28,13 +28,10 @@ size_t bparser_read(bparser* parser, void* buf, unsigned int pos, size_t size) {
 
     switch (parser->mode) {
         case BASEER_MODE_MEMORY:
-            unsigned int chunck_size=0;
-            if(pos + size > parser->size) {
-                return 0;
-            } else {
-                chunck_size = size;
+            if(parser->block && pos + size > parser->size) {
+                return parser->size;
             }
-            memcpy(buf, (unsigned char*)parser->block+pos, chunck_size);
+            memcpy(buf, parser->block+pos, size);
             return size;
 
         case BASEER_MODE_STREAM:
@@ -44,7 +41,7 @@ size_t bparser_read(bparser* parser, void* buf, unsigned int pos, size_t size) {
 
         case BASEER_MODE_BOTH:
             if (parser->block && pos + size < parser->size) {
-                memcpy(buf, (unsigned char*)parser->block + pos, size);
+                memcpy(buf, parser->block + pos, size);
                 return size;
             } else if (parser->fp) {
                 if (fseek(parser->fp, pos, SEEK_SET) != 0) return 0;

--- a/modules/bx_deElf/bx_deElf.c
+++ b/modules/bx_deElf/bx_deElf.c
@@ -5,7 +5,9 @@
 #include <string.h>
 #include <unistd.h>
 #include <errno.h>
+#include <fcntl.h>
 #include <sys/wait.h>
+#include <sys/types.h>
 #include <stdint.h>
 
 #ifndef RETDEC_DEFAULT_BIN
@@ -259,25 +261,48 @@ static int dump_to_temp_file(bparser *parser, const char *path) {
 }
 
 static bool run_retdec(const char *in_path, const char *out_path) {
-    char cmd[2048];
-    const char *retdec_bin = RETDEC_DEFAULT_BIN;
+    /* Allow overriding the decompiler path via environment variable */
+    const char *retdec_bin = getenv("BASEER_RETDEC_BIN");
+    if (!retdec_bin || *retdec_bin == '\0') {
+        retdec_bin = RETDEC_DEFAULT_BIN;
+    }
 
-    int n = snprintf(cmd, sizeof(cmd), "%s --cleanup -s %s -o %s > /dev/null 2>&1", retdec_bin, in_path, out_path);
-    if (n < 0 || n >= (size_t)sizeof(cmd)) {
-        fprintf(stderr, "[!] command too long or snprintf error\n");
+    pid_t pid = fork();
+    if (pid == -1) {
+        perror("fork");
         return false;
     }
 
-    int ret = system(cmd);
-    if (ret == -1) {
-        perror("system");
+    if (pid == 0) {
+        /* Child process: redirect stdout/stderr to /dev/null */
+        int devnull = open("/dev/null", O_WRONLY);
+        if (devnull != -1) {
+            dup2(devnull, STDOUT_FILENO);
+            dup2(devnull, STDERR_FILENO);
+            close(devnull);
+        }
+        execl(retdec_bin, retdec_bin, "--cleanup", "-s", in_path, "-o", out_path, (char *)NULL);
+        /* execl only returns on failure */
+        _exit(127);
+    }
+
+    /* Parent process: wait for child */
+    int status;
+    if (waitpid(pid, &status, 0) == -1) {
+        perror("waitpid");
         return false;
     }
 
-    if (WIFEXITED(ret)){
-        int exit_status = WEXITSTATUS(ret);
+    if (WIFEXITED(status)) {
+        int exit_status = WEXITSTATUS(status);
+        if (exit_status == 127) {
+            fprintf(stderr, "[!] Failed to execute retdec-decompiler at: %s\n"
+                            "[!] Install it with: sudo /opt/baseer/install_decompiler.sh\n"
+                            "[!] Or set BASEER_RETDEC_BIN environment variable\n", retdec_bin);
+            return false;
+        }
         if (exit_status != 0) {
-            fprintf(stderr, "[!] retdec-decompiler exited with status %d\n[!] you need to install decompiler using this command:\nsudo /opt/baseer/install_decompiler.sh\n", exit_status);
+            fprintf(stderr, "[!] retdec-decompiler exited with status %d\n", exit_status);
             return false;
         }
     } else {

--- a/modules/bx_elf/bx_elf.c
+++ b/modules/bx_elf/bx_elf.c
@@ -4,37 +4,6 @@ bool bx_elf(bparser* parser, void *arg)
 {
     int argc = *((inputs*)arg) -> argc;
     char** args = ((inputs*)arg) -> args;
-    hashmap_t *maps = ((inputs*)arg) -> map;
-    
-    // create hashmap of any hashmaps needed by baseer extentions to used it for other extentions...
-    // ((inputs*)arg) -> map = create_map();
-    // hashmap_t *maps = ((inputs*)arg) -> map;
-    // if((hashmap_t*)get(maps, "sections") != NULL){
-    //     hashmap_t *map = (hashmap_t*)get(maps, "sections");
-    // }
-
-    // 32 bit
-    // if((hashmap_t*)get(maps, "symbols") != NULL){
-    //     hashmap_t *symbols = (hashmap_t*)get(maps, "symbols");
-    //     if((Elf32_Sym*)get(symbols, "main") != NULL){
-    //         Elf32_Sym* func = get(symbols, "main");
-    //         func.st_value; // offset
-    //         func.st_size;  // size
-    //     }
-    // }
-
-    // 64 bit
-    // if((hashmap_t*)get(maps, "symbols") != NULL){
-    //     hashmap_t *symbols = (hashmap_t*)get(maps, "symbols");
-    //     if((Elf64_Sym*)get(symbols, "main") != NULL){
-    //         Elf64_Sym* func = get(symbols, "main");
-    //         // func -> st_value; // offset
-    //         // func -> st_size;  // size
-    //         printf("%offset: lx\n size: %d\n", func->st_value, func->st_size);
-    //     }
-    // }
-
-
 
     for(int i = 2; i < argc; i++) {
         if(strcmp("-m", args[i]) == 0) {
@@ -45,14 +14,12 @@ bool bx_elf(bparser* parser, void *arg)
             bparser_apply(parser, b_debugger, arg);
         } else if (strcmp("-c", args[i]) == 0) {
             bparser_apply(parser, decompile_elf, arg);
-        }else if(strcmp("--args", args[i]) == 0){
+        } else if(strcmp("--args", args[i]) == 0) {
             break;
-        }else {
+        } else {
             fprintf(stderr, "[!] Unsupported flag: %s\n", args[i]);
         }
     }
-
-    // free_maps(maps);
 
     return true;
 }

--- a/modules/bx_elf_disasm/bx_elf_disasm.c
+++ b/modules/bx_elf_disasm/bx_elf_disasm.c
@@ -45,16 +45,32 @@
  * @param shdrs Pointer to the array of ELF32 section headers.
  * @param parser Pointer to a bparser structure for reading binary data.
  */
-void dump_disasm_elf32_shdr(Elf32_Ehdr* elf , Elf32_Shdr* shdrs, bparser* parser)
+void  dump_disasm_elf32_shdr(Elf32_Ehdr* elf, Elf32_Shdr* shdrs, bparser* parser, void* arg) 
 {
+    if(shdrs == NULL) return;
+
     Elf32_Shdr shstr = shdrs[elf->e_shstrndx];
     const char* shstrtab = (const char*)(parser->block + shstr.sh_offset);
 
     printf(COLOR_BLUE "\n=== Sections ===\n" COLOR_RESET);
     // print_section_header_legend();
 
+    // ======================================= init maps  =================================================
     // create hashmap of section headers to retreve the specifa name of section header needed
-    hashmap_t *map = create_map();
+    // hashmap_t *map = create_map();
+    hashmap_t *maps = ((inputs*)arg) -> map;
+    if((hashmap_t*)get(maps, "sections") == NULL){
+        insert(maps, "sections", create_map());
+    }
+
+    if((hashmap_t*)get(maps, "symbols") == NULL){
+        insert(maps, "symbols", create_map());
+    }
+
+    // ======================================= init maps  =================================================
+
+    hashmap_t *map = (hashmap_t*)get(maps, "sections");
+    hashmap_t *symbols = (hashmap_t*)get(maps, "symbols");
     
     for (int i = 0; i < elf->e_shnum; i++) {
 
@@ -66,7 +82,9 @@ void dump_disasm_elf32_shdr(Elf32_Ehdr* elf , Elf32_Shdr* shdrs, bparser* parser
         const char* type_str = sh_type_to_str(shdrs[i].sh_type);
 
         // Insert section header pointers into a hashmap for quick retrieval by name
-        insert(map, name, &shdrs[i]);
+        if((Elf32_Shdr*)get(map, name) == NULL){
+            insert(map, name, &shdrs[i]);
+        }
 
         if(shdrs[i].sh_flags & SHF_EXECINSTR) {
             // Flags
@@ -97,11 +115,41 @@ void dump_disasm_elf32_shdr(Elf32_Ehdr* elf , Elf32_Shdr* shdrs, bparser* parser
     //     printf("\n\n");
     // }
 
+    // ================ print tables ==================
+    for (int i = 0; i < elf->e_shnum; i++) {
+        Elf32_Shdr curr_shd = shdrs[i];
+        if(curr_shd.sh_link == 0) continue;
+        Elf32_Shdr linked_shd = shdrs[curr_shd.sh_link];
+
+        // check is it table type and have like `SYMTAB` `DYNSYMTAB` `REL` `RELA` and so on... and there LINK section for names.
+        if (curr_shd.sh_type == SHT_SYMTAB && linked_shd.sh_type == SHT_STRTAB) {
+            print_symbols_32bit(parser, elf, shdrs, &curr_shd, &linked_shd);
+
+        } else if(curr_shd.sh_type == SHT_DYNSYM && linked_shd.sh_type == SHT_STRTAB){
+            // TODO: need to make print_dynmaic_symbols ...
+            print_symbols_32bit(parser, elf, shdrs, &curr_shd, &linked_shd);
+
+        } else if(curr_shd.sh_type == SHT_REL){
+            // TODO: need to make print_rel ...
+            print_rela_32bit(parser, elf, shdrs, &curr_shd, &linked_shd);
+        } else if(curr_shd.sh_type == SHT_RELA){
+            print_rela_32bit(parser, elf, shdrs, &curr_shd, &linked_shd);
+
+        } else if(curr_shd.sh_type == SHT_RELR){
+            // TODO: need to make print_rela ...
+            print_rela_32bit(parser, elf, shdrs, &curr_shd, &linked_shd);
+        } else if(curr_shd.sh_type == SHT_DYNAMIC){
+            // TODO
+            // print_symbols_32bit(parser, elf, shdrs, &curr_shd, &linked_shd);
+            print_dynamic_table_32bit(parser, elf, shdrs, &curr_shd, &linked_shd);
+        }
+    }
+
+
     if((symtab = (Elf32_Shdr*)get(map, ".symtab")) != NULL && (strtab = (Elf32_Shdr*)get(map, ".strtab")) != NULL) {
         print_symbols_with_disasm_32bit(parser, elf, shdrs, symtab, strtab);
     }
 
-    free_map(map);
 }
 
 /**
@@ -350,6 +398,7 @@ bool print_elf_disasm(bparser* parser, void* args) {
         Elf32_Shdr* shdrs = (Elf32_Shdr*)(data + elf->e_shoff);
 
         printf(COLOR_GREEN "Entry point: " COLOR_RESET "0x%x\n", elf->e_entry);
+        printf(COLOR_GREEN "Program headers: " COLOR_RESET "%d (offset: 0x%x)\n", elf->e_phnum, elf->e_phoff);
         printf(COLOR_GREEN "Section headers: " COLOR_RESET "%d (offset: 0x%x)\n", elf->e_shnum, elf->e_shoff);
         printf(COLOR_GREEN "Section header string table index: " COLOR_RESET "%d\n", elf->e_shstrndx);
         printf(COLOR_GREEN "File Type: " COLOR_RESET "%s (%d)\n",
@@ -366,8 +415,14 @@ bool print_elf_disasm(bparser* parser, void* args) {
             return false;
         }
       
-        dump_disasm_elf32_shdr(elf, shdrs, parser);
-        dump_disasm_elf32_phdr(elf, phdr, parser);
+
+        if(elf->e_shnum > 0)
+            dump_disasm_elf32_shdr(elf, shdrs, parser, args);
+
+        if(elf->e_phnum > 0)
+            dump_disasm_elf32_phdr(elf, phdr, parser);
+
+
 
     } else if (bit_type == ELFCLASS64) {
         Elf64_Ehdr* elf = (Elf64_Ehdr*) data;
@@ -375,6 +430,7 @@ bool print_elf_disasm(bparser* parser, void* args) {
         Elf64_Shdr* shdrs = (Elf64_Shdr*)(data + elf->e_shoff);
 
         printf(COLOR_GREEN "Entry point: " COLOR_RESET "0x%lx\n", elf->e_entry);
+        printf(COLOR_GREEN "Program headers: " COLOR_RESET "%d (offset: 0x%lx)\n", elf->e_phnum, elf->e_phoff);
         printf(COLOR_GREEN "Section headers: " COLOR_RESET "%d (offset: 0x%lx)\n", elf->e_shnum, elf->e_shoff);
         printf(COLOR_GREEN "Section header string table index: " COLOR_RESET "%d\n", elf->e_shstrndx);
         printf(COLOR_GREEN "File Type: " COLOR_RESET "%s (%d)\n",
@@ -389,8 +445,11 @@ bool print_elf_disasm(bparser* parser, void* args) {
             return false;
         }
 
-        dump_disasm_elf64_shdr(elf, shdrs, parser);
-        dump_disasm_elf64_phdr(elf, phdr, parser);
+        if(elf->e_shnum > 0)
+            dump_disasm_elf64_shdr(elf, shdrs, parser);
+
+        if(elf->e_phnum > 0)
+            dump_disasm_elf64_phdr(elf, phdr, parser);
 
     } else {
         printf(COLOR_RED "Unknown ELF class: %d\n" COLOR_RESET, bit_type);

--- a/modules/bx_macho/bx_macho.c
+++ b/modules/bx_macho/bx_macho.c
@@ -1,31 +1,42 @@
+/**
+ * @file bx_macho.c
+ * @brief Mach-O format handler for Baseer.
+ *
+ * Dispatches Mach-O analysis based on command-line flags:
+ *   -m  Metadata (headers, load commands, segments, symbols)
+ *   -a  Disassembly (executable sections with symbol labels)
+ *   -d  Debugger (ptrace-based, same as ELF)
+ *   -c  Decompiler (RetDec integration, same as ELF)
+ */
 #include "./bx_macho.h"
 #include "../../baseer.h"
-#include <string.h>
 #include "../b_macho_metadata/b_macho_metadata.h"
+#include "../bx_macho_disasm/bx_macho_disasm.h"
+#include "../b_debugger/debugger.h"
+#include "../bx_deElf/bx_deElf.h"
+#include <string.h>
+#include <stdio.h>
 
-bool bx_macho(bparser* parser, void *arg)
+bool bx_macho(bparser *parser, void *arg)
 {
-    int argc = *((inputs*)arg) -> argc;
-    char** args = ((inputs*)arg) -> args;
-    hashmap_t *maps = ((inputs*)arg) -> map;
+    int argc = *((inputs *)arg)->argc;
+    char **args = ((inputs *)arg)->args;
 
-    for(int i = 2; i < argc; i++) {
-        if(strcmp("-m", args[i]) == 0) {
+    for (int i = 2; i < argc; i++) {
+        if (strcmp("-m", args[i]) == 0) {
             bparser_apply(parser, b_macho_metadata, arg);
-        // } else if (strcmp("-a", args[i]) == 0) {
-            // bparser_apply(parser, print_elf_disasm, arg);
-        // } else if(strcmp("-d", args[i]) == 0) {
-            // bparser_apply(parser, b_debugger, arg);
-        // } else if (strcmp("-c", args[i]) == 0) {
-            // bparser_apply(parser, decompile_elf, arg);
-        }else if(strcmp("--args", args[i]) == 0){
+        } else if (strcmp("-a", args[i]) == 0) {
+            bparser_apply(parser, print_macho_disasm, arg);
+        } else if (strcmp("-d", args[i]) == 0) {
+            bparser_apply(parser, b_debugger, arg);
+        } else if (strcmp("-c", args[i]) == 0) {
+            bparser_apply(parser, decompile_elf, arg);
+        } else if (strcmp("--args", args[i]) == 0) {
             break;
-        }else {
-            fprintf(stderr, "[!] Unsupported flag: %s\n", args[i]);
+        } else {
+            fprintf(stderr, "[!] Unsupported flag for Mach-O: %s\n", args[i]);
         }
     }
-
-    // free_maps(maps);
 
     return true;
 }

--- a/modules/bx_macho_disasm/bx_macho_disasm.c
+++ b/modules/bx_macho_disasm/bx_macho_disasm.c
@@ -1,0 +1,340 @@
+/**
+ * @file bx_macho_disasm.c
+ * @brief Mach-O disassembly module using udis86.
+ *
+ * Disassembles executable Mach-O sections with:
+ * - Per-function labels from the symbol table
+ * - Color-coded instruction output
+ * - Support for both 32-bit and 64-bit Mach-O files
+ */
+#include "bx_macho_disasm.h"
+#include "../../baseer.h"
+#include "../bparser/bparser.h"
+#include "../bx_macho_utils/bx_macho_utils.h"
+#include "../bx_elf_utils/bx_elf_utils.h"
+#include "../../utils/ui.h"
+#include "macho.h"
+#include "udis86.h"
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+
+/* =================== Internal helpers =================== */
+
+/**
+ * @brief Symbol entry for sorting and lookup during disassembly.
+ */
+typedef struct {
+    uint64_t addr;
+    const char *name;
+} macho_sym_entry;
+
+static int sym_compare(const void *a, const void *b)
+{
+    const macho_sym_entry *sa = (const macho_sym_entry *)a;
+    const macho_sym_entry *sb = (const macho_sym_entry *)b;
+    if (sa->addr < sb->addr) return -1;
+    if (sa->addr > sb->addr) return 1;
+    return 0;
+}
+
+/**
+ * @brief Look up a symbol name by address using binary search.
+ */
+static const char* find_symbol(const macho_sym_entry *syms, uint32_t count, uint64_t addr)
+{
+    if (!syms || count == 0) return NULL;
+
+    int lo = 0, hi = (int)count - 1;
+    while (lo <= hi) {
+        int mid = lo + (hi - lo) / 2;
+        if (syms[mid].addr == addr) return syms[mid].name;
+        if (syms[mid].addr < addr) lo = mid + 1;
+        else hi = mid - 1;
+    }
+    return NULL;
+}
+
+/**
+ * @brief Collect function symbols from a 64-bit Mach-O symbol table.
+ */
+static macho_sym_entry* collect_symbols_64(const unsigned char *block, size_t file_size,
+                                            uint32_t symoff, uint32_t nsyms,
+                                            uint32_t stroff, uint32_t strsize,
+                                            uint32_t *out_count)
+{
+    *out_count = 0;
+    if (symoff + (size_t)nsyms * sizeof(struct nlist_64) > file_size) return NULL;
+    if (stroff + strsize > file_size) return NULL;
+
+    const struct nlist_64 *nl = (const struct nlist_64 *)(block + symoff);
+    const char *strs = (const char *)(block + stroff);
+
+    /* Count function symbols (defined in a section, not stab) */
+    uint32_t count = 0;
+    for (uint32_t i = 0; i < nsyms; i++) {
+        if ((nl[i].n_type & N_STAB) == 0 && (nl[i].n_type & N_TYPE) == N_SECT && nl[i].n_value != 0)
+            count++;
+    }
+    if (count == 0) return NULL;
+
+    macho_sym_entry *syms = malloc(count * sizeof(macho_sym_entry));
+    if (!syms) return NULL;
+
+    uint32_t idx = 0;
+    for (uint32_t i = 0; i < nsyms; i++) {
+        if ((nl[i].n_type & N_STAB) == 0 && (nl[i].n_type & N_TYPE) == N_SECT && nl[i].n_value != 0) {
+            syms[idx].addr = nl[i].n_value;
+            syms[idx].name = (nl[i].n_strx < strsize) ? strs + nl[i].n_strx : "???";
+            idx++;
+        }
+    }
+
+    qsort(syms, count, sizeof(macho_sym_entry), sym_compare);
+    *out_count = count;
+    return syms;
+}
+
+/**
+ * @brief Collect function symbols from a 32-bit Mach-O symbol table.
+ */
+static macho_sym_entry* collect_symbols_32(const unsigned char *block, size_t file_size,
+                                            uint32_t symoff, uint32_t nsyms,
+                                            uint32_t stroff, uint32_t strsize,
+                                            uint32_t *out_count)
+{
+    *out_count = 0;
+    if (symoff + (size_t)nsyms * sizeof(struct nlist) > file_size) return NULL;
+    if (stroff + strsize > file_size) return NULL;
+
+    const struct nlist *nl = (const struct nlist *)(block + symoff);
+    const char *strs = (const char *)(block + stroff);
+
+    uint32_t count = 0;
+    for (uint32_t i = 0; i < nsyms; i++) {
+        if ((nl[i].n_type & N_STAB) == 0 && (nl[i].n_type & N_TYPE) == N_SECT && nl[i].n_value != 0)
+            count++;
+    }
+    if (count == 0) return NULL;
+
+    macho_sym_entry *syms = malloc(count * sizeof(macho_sym_entry));
+    if (!syms) return NULL;
+
+    uint32_t idx = 0;
+    for (uint32_t i = 0; i < nsyms; i++) {
+        if ((nl[i].n_type & N_STAB) == 0 && (nl[i].n_type & N_TYPE) == N_SECT && nl[i].n_value != 0) {
+            syms[idx].addr = nl[i].n_value;
+            syms[idx].name = (nl[i].n_strx < strsize) ? strs + nl[i].n_strx : "???";
+            idx++;
+        }
+    }
+
+    qsort(syms, count, sizeof(macho_sym_entry), sym_compare);
+    *out_count = count;
+    return syms;
+}
+
+/**
+ * @brief Disassemble a section's bytes with symbol labels.
+ */
+static void disasm_section_with_symbols(const unsigned char *code, size_t size,
+                                         uint64_t base_addr, int mode,
+                                         const macho_sym_entry *syms, uint32_t nsyms)
+{
+    ud_t ud_obj;
+    ud_init(&ud_obj);
+    ud_set_input_buffer(&ud_obj, code, size);
+    ud_set_mode(&ud_obj, mode);
+    ud_set_pc(&ud_obj, base_addr);
+    ud_set_syntax(&ud_obj, UD_SYN_INTEL);
+
+    while (ud_disassemble(&ud_obj)) {
+        uint64_t pc = ud_insn_off(&ud_obj);
+
+        /* Check if this address has a symbol label */
+        const char *label = find_symbol(syms, nsyms, pc);
+        if (label) {
+            printf("\n" COLOR_YELLOW "<%s>:" COLOR_RESET "\n", label);
+        }
+
+        /* Print address and instruction */
+        const char *asm_str = ud_insn_asm(&ud_obj);
+        printf("  " COLOR_GREEN "0x%08lx" COLOR_RESET ":  ", (unsigned long)pc);
+        print_highlight_asm(asm_str);
+        printf("\n");
+    }
+}
+
+/* =================== 64-bit Mach-O disassembly =================== */
+
+static bool disasm_macho_64(const unsigned char *block, size_t file_size)
+{
+    mach_header_64 *hdr = (mach_header_64 *)block;
+
+    if (file_size < sizeof(mach_header_64)) return false;
+    if ((size_t)hdr->sizeofcmds + sizeof(mach_header_64) > file_size) return false;
+
+    printf(COLOR_BLUE "=== Mach-O Disassembly (64-bit) ===\n" COLOR_RESET);
+    printf(COLOR_GREEN "CPU Type:      " COLOR_RESET "%s\n", cpu_type_to_string(hdr->cputype));
+    printf(COLOR_GREEN "File Type:     " COLOR_RESET "%s\n", get_mach_o_type(hdr->filetype));
+
+    /* Determine disassembly mode */
+    int mode = 64;
+    if (hdr->cputype == CPU_TYPE_X86) mode = 32;
+    else if (hdr->cputype == CPU_TYPE_ARM64 || hdr->cputype == CPU_TYPE_ARM) {
+        fprintf(stderr, COLOR_RED "[!] ARM disassembly not yet supported (x86/x86-64 only)\n" COLOR_RESET);
+        return false;
+    }
+
+    /* First pass: find LC_SYMTAB for symbol labels */
+    uint32_t symoff = 0, nsyms = 0, stroff = 0, strsize = 0;
+    const unsigned char *cmd_ptr = block + sizeof(mach_header_64);
+    for (uint32_t i = 0; i < hdr->ncmds; i++) {
+        if (cmd_ptr + sizeof(load_command) > block + file_size) break;
+        load_command *lc = (load_command *)cmd_ptr;
+        if (lc->cmdsize < sizeof(load_command) || cmd_ptr + lc->cmdsize > block + file_size) break;
+
+        if (lc->cmd == LC_SYMTAB) {
+            struct symtab_command *sc = (struct symtab_command *)cmd_ptr;
+            symoff = sc->symoff; nsyms = sc->nsyms;
+            stroff = sc->stroff; strsize = sc->strsize;
+        }
+        cmd_ptr += lc->cmdsize;
+    }
+
+    /* Collect symbols */
+    uint32_t sym_count = 0;
+    macho_sym_entry *syms = collect_symbols_64(block, file_size, symoff, nsyms, stroff, strsize, &sym_count);
+
+    if (sym_count > 0)
+        printf(COLOR_GREEN "Symbols:       " COLOR_RESET "%u function symbols found\n", sym_count);
+
+    /* Second pass: disassemble executable sections */
+    cmd_ptr = block + sizeof(mach_header_64);
+    for (uint32_t i = 0; i < hdr->ncmds; i++) {
+        if (cmd_ptr + sizeof(load_command) > block + file_size) break;
+        load_command *lc = (load_command *)cmd_ptr;
+        if (lc->cmdsize < sizeof(load_command) || cmd_ptr + lc->cmdsize > block + file_size) break;
+
+        if (lc->cmd == LC_SEGMENT_64) {
+            segment_command_64 *seg = (segment_command_64 *)cmd_ptr;
+            const unsigned char *sec_ptr = cmd_ptr + sizeof(segment_command_64);
+
+            for (uint32_t s = 0; s < seg->nsects; s++) {
+                if (sec_ptr + sizeof(section_64) > block + file_size) break;
+                section_64 *sec = (section_64 *)sec_ptr;
+
+                if (macho_section_is_executable(sec->flags) && sec->size > 0) {
+                    if (sec->offset + sec->size <= file_size) {
+                        printf(COLOR_BLUE "\n--- %s,%s (0x%lx bytes at offset 0x%x) ---\n" COLOR_RESET,
+                               sec->segname, sec->sectname,
+                               (unsigned long)sec->size, sec->offset);
+
+                        const unsigned char *code = block + sec->offset;
+                        disasm_section_with_symbols(code, sec->size, sec->addr, mode, syms, sym_count);
+                    }
+                }
+                sec_ptr += sizeof(section_64);
+            }
+        }
+        cmd_ptr += lc->cmdsize;
+    }
+
+    free(syms);
+    printf("\n");
+    return true;
+}
+
+/* =================== 32-bit Mach-O disassembly =================== */
+
+static bool disasm_macho_32(const unsigned char *block, size_t file_size)
+{
+    mach_header *hdr = (mach_header *)block;
+
+    if (file_size < sizeof(mach_header)) return false;
+    if ((size_t)hdr->sizeofcmds + sizeof(mach_header) > file_size) return false;
+
+    printf(COLOR_BLUE "=== Mach-O Disassembly (32-bit) ===\n" COLOR_RESET);
+    printf(COLOR_GREEN "CPU Type:      " COLOR_RESET "%s\n", cpu_type_to_string(hdr->cputype));
+    printf(COLOR_GREEN "File Type:     " COLOR_RESET "%s\n", get_mach_o_type(hdr->filetype));
+
+    int mode = 32;
+
+    /* First pass: find LC_SYMTAB */
+    uint32_t symoff = 0, nsyms = 0, stroff = 0, strsize = 0;
+    const unsigned char *cmd_ptr = block + sizeof(mach_header);
+    for (uint32_t i = 0; i < hdr->ncmds; i++) {
+        if (cmd_ptr + sizeof(load_command) > block + file_size) break;
+        load_command *lc = (load_command *)cmd_ptr;
+        if (lc->cmdsize < sizeof(load_command) || cmd_ptr + lc->cmdsize > block + file_size) break;
+
+        if (lc->cmd == LC_SYMTAB) {
+            struct symtab_command *sc = (struct symtab_command *)cmd_ptr;
+            symoff = sc->symoff; nsyms = sc->nsyms;
+            stroff = sc->stroff; strsize = sc->strsize;
+        }
+        cmd_ptr += lc->cmdsize;
+    }
+
+    uint32_t sym_count = 0;
+    macho_sym_entry *syms = collect_symbols_32(block, file_size, symoff, nsyms, stroff, strsize, &sym_count);
+
+    if (sym_count > 0)
+        printf(COLOR_GREEN "Symbols:       " COLOR_RESET "%u function symbols found\n", sym_count);
+
+    /* Second pass: disassemble executable sections */
+    cmd_ptr = block + sizeof(mach_header);
+    for (uint32_t i = 0; i < hdr->ncmds; i++) {
+        if (cmd_ptr + sizeof(load_command) > block + file_size) break;
+        load_command *lc = (load_command *)cmd_ptr;
+        if (lc->cmdsize < sizeof(load_command) || cmd_ptr + lc->cmdsize > block + file_size) break;
+
+        if (lc->cmd == LC_SEGMENT) {
+            segment_command *seg = (segment_command *)cmd_ptr;
+            const unsigned char *sec_ptr = cmd_ptr + sizeof(segment_command);
+
+            for (uint32_t s = 0; s < seg->nsects; s++) {
+                if (sec_ptr + sizeof(section) > block + file_size) break;
+                section *sec = (section *)sec_ptr;
+
+                if (macho_section_is_executable(sec->flags) && sec->size > 0) {
+                    if (sec->offset + sec->size <= file_size) {
+                        printf(COLOR_BLUE "\n--- %s,%s (0x%x bytes at offset 0x%x) ---\n" COLOR_RESET,
+                               sec->segname, sec->sectname, sec->size, sec->offset);
+
+                        const unsigned char *code = block + sec->offset;
+                        disasm_section_with_symbols(code, sec->size, sec->addr, mode, syms, sym_count);
+                    }
+                }
+                sec_ptr += sizeof(section);
+            }
+        }
+        cmd_ptr += lc->cmdsize;
+    }
+
+    free(syms);
+    printf("\n");
+    return true;
+}
+
+/* =================== Public entry point =================== */
+
+bool print_macho_disasm(bparser *parser, void *arg)
+{
+    (void)arg;
+    if (!parser || !parser->block || parser->size < sizeof(uint32_t)) {
+        fprintf(stderr, COLOR_RED "[!] Invalid parser state for disassembly\n" COLOR_RESET);
+        return false;
+    }
+
+    const unsigned char *block = (const unsigned char *)parser->block;
+    uint32_t magic = *(const uint32_t *)block;
+
+    if (magic == MH_MAGIC_64)
+        return disasm_macho_64(block, parser->size);
+    else if (magic == MH_MAGIC)
+        return disasm_macho_32(block, parser->size);
+
+    fprintf(stderr, COLOR_RED "[!] Not a valid Mach-O file\n" COLOR_RESET);
+    return false;
+}

--- a/modules/bx_macho_disasm/bx_macho_disasm.h
+++ b/modules/bx_macho_disasm/bx_macho_disasm.h
@@ -1,0 +1,26 @@
+/**
+ * @file bx_macho_disasm.h
+ * @brief Mach-O disassembly module for Baseer.
+ *
+ * Provides disassembly of executable sections in Mach-O files
+ * using the udis86 engine, with per-function symbol labeling.
+ */
+#ifndef BX_MACHO_DISASM_H
+#define BX_MACHO_DISASM_H
+
+#include "../bparser/bparser.h"
+
+/**
+ * @brief Disassemble executable sections of a Mach-O binary.
+ *
+ * Iterates over all segments/sections, finds those with executable
+ * attributes (S_ATTR_PURE_INSTRUCTIONS), and disassembles them.
+ * If a symbol table is present, functions are labeled by name.
+ *
+ * @param parser Pointer to the bparser with the file loaded in memory.
+ * @param arg    Pointer to inputs struct (unused for disasm).
+ * @return true on success, false on error.
+ */
+bool print_macho_disasm(bparser *parser, void *arg);
+
+#endif /* BX_MACHO_DISASM_H */

--- a/modules/bx_macho_utils/bx_macho_utils.c
+++ b/modules/bx_macho_utils/bx_macho_utils.c
@@ -1,198 +1,405 @@
+/**
+ * @file bx_macho_utils.c
+ * @brief Utility functions for Mach-O binary analysis.
+ */
 #include "bx_macho_utils.h"
 #include "../../utils/ui.h"
 #include <stdio.h>
-const char* get_mach_o_type(unsigned int type) 
+#include <string.h>
+
+/* =================== Type-to-string conversions =================== */
+
+const char* get_mach_o_type(unsigned int type)
 {
     switch (type) {
-        case 0x1: return "MH_OBJECT (relocatable object file)";
-        case 0x2: return "MH_EXECUTE (demand paged executable file)";
-        case 0x3: return "MH_FVMLIB (fixed VM shared library file)";
-        case 0x4: return "MH_CORE (core file)";
-        case 0x5: return "MH_PRELOAD (preloaded executable file)";
-        case 0x6: return "MH_DYLIB (dynamically bound shared library)";
-        case 0x7: return "MH_DYLINKER (dynamic link editor)";
-        case 0x8: return "MH_BUNDLE (dynamically bound bundle file)";
-        case 0x9: return "MH_DYLIB_STUB (shared library stub for static linking only)";
-        case 0xa: return "MH_DSYM (debug symbols companion file)";
-        case 0xb: return "MH_KEXT_BUNDLE (x86_64 kext bundle)";
-        case 0xc: return "MH_FILESET (set of mach-o's)";
-        default:  return "Unknown Mach-O file type";
+        case MH_OBJECT:     return "MH_OBJECT (relocatable object file)";
+        case MH_EXECUTE:    return "MH_EXECUTE (demand paged executable)";
+        case MH_FVMLIB:     return "MH_FVMLIB (fixed VM shared library)";
+        case MH_CORE:       return "MH_CORE (core file)";
+        case MH_PRELOAD:    return "MH_PRELOAD (preloaded executable)";
+        case MH_DYLIB:      return "MH_DYLIB (dynamically bound shared library)";
+        case MH_DYLINKER:   return "MH_DYLINKER (dynamic link editor)";
+        case MH_BUNDLE:     return "MH_BUNDLE (dynamically bound bundle)";
+        case MH_DYLIB_STUB: return "MH_DYLIB_STUB (shared library stub)";
+        case MH_DSYM:       return "MH_DSYM (debug symbols companion)";
+        case MH_KEXT_BUNDLE:return "MH_KEXT_BUNDLE (x86_64 kext)";
+        case MH_FILESET:    return "MH_FILESET (set of mach-o's)";
+        default:            return "Unknown Mach-O file type";
     }
 }
 
-void print_mach_o_flags(unsigned int flags) 
+const char* cpu_type_to_string(cpu_type_t cputype)
 {
-    if (flags & 0x1) printf(" - MH_NOUNDEFS\n");
-    if (flags & 0x2) printf(" - MH_INCRLINK\n");
-    if (flags & 0x4) printf(" - MH_DYLDLINK\n");
-    if (flags & 0x8) printf(" - MH_BINDATLOAD\n");
-    if (flags & 0x10) printf(" - MH_PREBOUND\n");
-    if (flags & 0x20) printf(" - MH_SPLIT_SEGS\n");
-    if (flags & 0x40) printf(" - MH_LAZY_INIT (obsolete)\n");
-    if (flags & 0x80) printf(" - MH_TWOLEVEL\n");
-    if (flags & 0x100) printf(" - MH_FORCE_FLAT\n");
-    if (flags & 0x200) printf(" - MH_NOMULTIDEFS\n");
-    if (flags & 0x400) printf(" - MH_NOFIXPREBINDING\n");
-    if (flags & 0x800) printf(" - MH_PREBINDABLE\n");
-    if (flags & 0x1000) printf(" - MH_ALLMODSBOUND\n");
-    if (flags & 0x2000) printf(" - MH_SUBSECTIONS_VIA_SYMBOLS\n");
-    if (flags & 0x4000) printf(" - MH_CANONICAL\n");
-    if (flags & 0x8000) printf(" - MH_WEAK_DEFINES\n");
-    if (flags & 0x10000) printf(" - MH_BINDS_TO_WEAK\n");
-    if (flags & 0x20000) printf(" - MH_ALLOW_STACK_EXECUTION\n");
-    if (flags & 0x40000) printf(" - MH_ROOT_SAFE\n");
-    if (flags & 0x80000) printf(" - MH_SETUID_SAFE\n");
-    if (flags & 0x100000) printf(" - MH_NO_REEXPORTED_DYLIBS\n");
-    if (flags & 0x200000) printf(" - MH_PIE\n");
-    if (flags & 0x400000) printf(" - MH_DEAD_STRIPPABLE_DYLIB\n");
-    if (flags & 0x800000) printf(" - MH_HAS_TLV_DESCRIPTORS\n");
-    if (flags & 0x1000000) printf(" - MH_NO_HEAP_EXECUTION\n");
-    if (flags & 0x02000000) printf(" - MH_APP_EXTENSION_SAFE\n");
-    if (flags & 0x04000000) printf(" - MH_NLIST_OUTOFSYNC_WITH_DYLDINFO\n");
-    if (flags & 0x08000000) printf(" - MH_SIM_SUPPORT\n");
-    if (flags & 0x80000000) printf(" - MH_DYLIB_IN_CACHE\n");
+    switch (cputype) {
+        case CPU_TYPE_X86:       return "x86 (i386)";
+        case CPU_TYPE_X86_64:    return "x86_64";
+        case CPU_TYPE_ARM:       return "ARM";
+        case CPU_TYPE_ARM64:     return "ARM64 (AArch64)";
+        case CPU_TYPE_POWERPC:   return "PowerPC";
+        case CPU_TYPE_POWERPC64: return "PowerPC64";
+        default:                 return "Unknown";
+    }
 }
 
-const char* get_load_command_name(uint32_t cmd) 
+const char* cpu_subtype_to_string(cpu_type_t cputype, cpu_subtype_t cpusubtype)
 {
-    uint32_t base = cmd & ~LC_REQ_DYLD; // Remove LC_REQ_DYLD bit if present
+    if (cputype == CPU_TYPE_X86_64) {
+        switch (cpusubtype) {
+            case CPU_SUBTYPE_X86_64_ALL: return "ALL";
+            case CPU_SUBTYPE_X86_64_H:   return "Haswell";
+            default:                     return "Unknown";
+        }
+    } else if (cputype == CPU_TYPE_ARM64) {
+        switch (cpusubtype) {
+            case CPU_SUBTYPE_ARM64_ALL: return "ALL";
+            case CPU_SUBTYPE_ARM64E:    return "ARM64E";
+            default:                    return "Unknown";
+        }
+    } else if (cputype == CPU_TYPE_X86) {
+        return (cpusubtype == CPU_SUBTYPE_X86_ALL) ? "ALL" : "Unknown";
+    }
+    return "Unknown";
+}
+
+const char* nlist_type_to_string(uint8_t n_type)
+{
+    if (n_type & N_STAB) return "STAB";
+    switch (n_type & N_TYPE) {
+        case N_UNDF: return (n_type & N_EXT) ? "UNDEF (ext)" : "UNDEF";
+        case N_ABS:  return (n_type & N_EXT) ? "ABS (ext)"   : "ABS";
+        case N_SECT: return (n_type & N_EXT) ? "SECT (ext)"  : "SECT";
+        case N_PBUD: return "PBUD";
+        case N_INDR: return "INDR";
+        default:     return "???";
+    }
+}
+
+const char* nlist_section_to_string(uint8_t n_sect)
+{
+    if (n_sect == NO_SECT) return "NO_SECT";
+    static char buf[16];
+    snprintf(buf, sizeof(buf), "sect_%u", n_sect);
+    return buf;
+}
+
+/* =================== Flag / field printers =================== */
+
+void print_mach_o_flags(unsigned int flags)
+{
+    struct { unsigned int mask; const char *name; } flag_table[] = {
+        { MH_NOUNDEFS,                     "MH_NOUNDEFS" },
+        { MH_INCRLINK,                     "MH_INCRLINK" },
+        { MH_DYLDLINK,                     "MH_DYLDLINK" },
+        { MH_BINDATLOAD,                   "MH_BINDATLOAD" },
+        { MH_PREBOUND,                     "MH_PREBOUND" },
+        { MH_SPLIT_SEGS,                   "MH_SPLIT_SEGS" },
+        { MH_LAZY_INIT,                    "MH_LAZY_INIT (obsolete)" },
+        { MH_TWOLEVEL,                     "MH_TWOLEVEL" },
+        { MH_FORCE_FLAT,                   "MH_FORCE_FLAT" },
+        { MH_NOMULTIDEFS,                  "MH_NOMULTIDEFS" },
+        { MH_NOFIXPREBINDING,              "MH_NOFIXPREBINDING" },
+        { MH_PREBINDABLE,                  "MH_PREBINDABLE" },
+        { MH_ALLMODSBOUND,                 "MH_ALLMODSBOUND" },
+        { MH_SUBSECTIONS_VIA_SYMBOLS,      "MH_SUBSECTIONS_VIA_SYMBOLS" },
+        { MH_CANONICAL,                    "MH_CANONICAL" },
+        { MH_WEAK_DEFINES,                 "MH_WEAK_DEFINES" },
+        { MH_BINDS_TO_WEAK,               "MH_BINDS_TO_WEAK" },
+        { MH_ALLOW_STACK_EXECUTION,        "MH_ALLOW_STACK_EXECUTION" },
+        { MH_ROOT_SAFE,                    "MH_ROOT_SAFE" },
+        { MH_SETUID_SAFE,                  "MH_SETUID_SAFE" },
+        { MH_NO_REEXPORTED_DYLIBS,         "MH_NO_REEXPORTED_DYLIBS" },
+        { MH_PIE,                          "MH_PIE" },
+        { MH_DEAD_STRIPPABLE_DYLIB,        "MH_DEAD_STRIPPABLE_DYLIB" },
+        { MH_HAS_TLV_DESCRIPTORS,          "MH_HAS_TLV_DESCRIPTORS" },
+        { MH_NO_HEAP_EXECUTION,            "MH_NO_HEAP_EXECUTION" },
+        { MH_APP_EXTENSION_SAFE,           "MH_APP_EXTENSION_SAFE" },
+        { MH_NLIST_OUTOFSYNC_WITH_DYLDINFO,"MH_NLIST_OUTOFSYNC_WITH_DYLDINFO" },
+        { MH_SIM_SUPPORT,                  "MH_SIM_SUPPORT" },
+        { MH_DYLIB_IN_CACHE,              "MH_DYLIB_IN_CACHE" },
+    };
+    int n = sizeof(flag_table) / sizeof(flag_table[0]);
+    for (int i = 0; i < n; i++) {
+        if (flags & flag_table[i].mask)
+            printf("    - %s\n", flag_table[i].name);
+    }
+}
+
+const char* get_load_command_name(uint32_t cmd)
+{
+    uint32_t base = cmd & ~LC_REQ_DYLD;
     switch (base) {
-        case 0x1: return "LC_SEGMENT — segment of this file to be mapped";
-        case 0x2: return "LC_SYMTAB — link-edit stab symbol table info";
-        case 0x3: return "LC_SYMSEG — link-edit gdb symbol table info (obsolete)";
-        case 0x4: return "LC_THREAD — thread state";
-        case 0x5: return "LC_UNIXTHREAD — unix thread (includes a stack)";
-        case 0x6: return "LC_LOADFVMLIB — load fixed VM shared library";
-        case 0x7: return "LC_IDFVMLIB — fixed VM shared library identification";
-        case 0x8: return "LC_IDENT — object identification info (obsolete)";
-        case 0x9: return "LC_FVMFILE — fixed VM file inclusion (internal use)";
-        case 0xa: return "LC_PREPAGE — prepage command (internal use)";
-        case 0xb: return "LC_DYSYMTAB — dynamic link-edit symbol table info";
-        case 0xc: return "LC_LOAD_DYLIB — load a dynamically linked shared library";
-        case 0xd: return "LC_ID_DYLIB — dynamically linked shared lib ident";
-        case 0xe: return "LC_LOAD_DYLINKER — load a dynamic linker";
-        case 0xf: return "LC_ID_DYLINKER — dynamic linker identification";
-        case 0x10: return "LC_PREBOUND_DYLIB — prebound dynamically linked library";
-        case 0x11: return "LC_ROUTINES — image routines";
-        case 0x12: return "LC_SUB_FRAMEWORK — sub framework";
-        case 0x13: return "LC_SUB_UMBRELLA — sub umbrella";
-        case 0x14: return "LC_SUB_CLIENT — sub client";
-        case 0x15: return "LC_SUB_LIBRARY — sub library";
-        case 0x16: return "LC_TWOLEVEL_HINTS — two-level namespace lookup hints";
-        case 0x17: return "LC_PREBIND_CKSUM — prebind checksum";
-        case 0x18: return "LC_LOAD_WEAK_DYLIB — load weak dylib (may be missing)";
-        case 0x19: return "LC_SEGMENT_64 — 64-bit segment";
-        case 0x1a: return "LC_ROUTINES_64 — 64-bit image routines";
-        case 0x1b: return "LC_UUID — unique build UUID";
-        case 0x1c: return "LC_RPATH — runtime search path (requires dyld)";
-        case 0x1d: return "LC_CODE_SIGNATURE — code signature data";
-        case 0x1e: return "LC_SEGMENT_SPLIT_INFO — segment split info";
-        case 0x1f: return "LC_REEXPORT_DYLIB — re-exported dylib (requires dyld)";
-        case 0x20: return "LC_LAZY_LOAD_DYLIB — delay load dylib until use";
-        case 0x21: return "LC_ENCRYPTION_INFO — encrypted segment info";
-        case 0x22: return "LC_DYLD_INFO — compressed dyld info";
-        case 0x23: return "LC_LOAD_UPWARD_DYLIB — upward dylib (requires dyld)";
-        case 0x24: return "LC_VERSION_MIN_MACOSX — minimum macOS version";
-        case 0x25: return "LC_VERSION_MIN_IPHONEOS — minimum iOS version";
-        case 0x26: return "LC_FUNCTION_STARTS — table of function starts";
-        case 0x27: return "LC_DYLD_ENVIRONMENT — dyld environment variable";
-        case 0x28: return "LC_MAIN — entry point (requires dyld)";
-        case 0x29: return "LC_DATA_IN_CODE — non-instruction regions";
-        case 0x2A: return "LC_SOURCE_VERSION — source version";
-        case 0x2B: return "LC_DYLIB_CODE_SIGN_DRS — dylib code signing DRs";
-        case 0x2C: return "LC_ENCRYPTION_INFO_64 — 64-bit encrypted segment";
-        case 0x2D: return "LC_LINKER_OPTION — linker options";
-        case 0x2E: return "LC_LINKER_OPTIMIZATION_HINT — optimization hints";
-        case 0x2F: return "LC_VERSION_MIN_TVOS — minimum tvOS version";
-        case 0x30: return "LC_VERSION_MIN_WATCHOS — minimum watchOS version";
-        case 0x31: return "LC_NOTE — arbitrary Mach-O note";
-        case 0x32: return "LC_BUILD_VERSION — build version info";
-        case 0x33: return "LC_DYLD_EXPORTS_TRIE — dyld exports trie";
-        case 0x34: return "LC_DYLD_CHAINED_FIXUPS — dyld chained fixups";
-        case 0x35: return "LC_FILESET_ENTRY — fileset entry";
-        default: return "Unknown or reserved load command";
+        case 0x1:  return "LC_SEGMENT";
+        case 0x2:  return "LC_SYMTAB";
+        case 0x3:  return "LC_SYMSEG (obsolete)";
+        case 0x4:  return "LC_THREAD";
+        case 0x5:  return "LC_UNIXTHREAD";
+        case 0x6:  return "LC_LOADFVMLIB";
+        case 0x7:  return "LC_IDFVMLIB";
+        case 0x8:  return "LC_IDENT (obsolete)";
+        case 0x9:  return "LC_FVMFILE";
+        case 0xa:  return "LC_PREPAGE";
+        case 0xb:  return "LC_DYSYMTAB";
+        case 0xc:  return "LC_LOAD_DYLIB";
+        case 0xd:  return "LC_ID_DYLIB";
+        case 0xe:  return "LC_LOAD_DYLINKER";
+        case 0xf:  return "LC_ID_DYLINKER";
+        case 0x10: return "LC_PREBOUND_DYLIB";
+        case 0x11: return "LC_ROUTINES";
+        case 0x12: return "LC_SUB_FRAMEWORK";
+        case 0x13: return "LC_SUB_UMBRELLA";
+        case 0x14: return "LC_SUB_CLIENT";
+        case 0x15: return "LC_SUB_LIBRARY";
+        case 0x16: return "LC_TWOLEVEL_HINTS";
+        case 0x17: return "LC_PREBIND_CKSUM";
+        case 0x18: return "LC_LOAD_WEAK_DYLIB";
+        case 0x19: return "LC_SEGMENT_64";
+        case 0x1a: return "LC_ROUTINES_64";
+        case 0x1b: return "LC_UUID";
+        case 0x1c: return "LC_RPATH";
+        case 0x1d: return "LC_CODE_SIGNATURE";
+        case 0x1e: return "LC_SEGMENT_SPLIT_INFO";
+        case 0x1f: return "LC_REEXPORT_DYLIB";
+        case 0x20: return "LC_LAZY_LOAD_DYLIB";
+        case 0x21: return "LC_ENCRYPTION_INFO";
+        case 0x22: return "LC_DYLD_INFO";
+        case 0x23: return "LC_LOAD_UPWARD_DYLIB";
+        case 0x24: return "LC_VERSION_MIN_MACOSX";
+        case 0x25: return "LC_VERSION_MIN_IPHONEOS";
+        case 0x26: return "LC_FUNCTION_STARTS";
+        case 0x27: return "LC_DYLD_ENVIRONMENT";
+        case 0x28: return "LC_MAIN";
+        case 0x29: return "LC_DATA_IN_CODE";
+        case 0x2A: return "LC_SOURCE_VERSION";
+        case 0x2B: return "LC_DYLIB_CODE_SIGN_DRS";
+        case 0x2C: return "LC_ENCRYPTION_INFO_64";
+        case 0x2D: return "LC_LINKER_OPTION";
+        case 0x2E: return "LC_LINKER_OPTIMIZATION_HINT";
+        case 0x2F: return "LC_VERSION_MIN_TVOS";
+        case 0x30: return "LC_VERSION_MIN_WATCHOS";
+        case 0x31: return "LC_NOTE";
+        case 0x32: return "LC_BUILD_VERSION";
+        case 0x33: return "LC_DYLD_EXPORTS_TRIE";
+        case 0x34: return "LC_DYLD_CHAINED_FIXUPS";
+        case 0x35: return "LC_FILESET_ENTRY";
+        default:   return "Unknown";
     }
 }
 
-void print_load_command_info(uint32_t cmd) 
+void print_load_command_info(uint32_t cmd)
 {
-    printf(COLOR_GREEN "Command:" COLOR_RESET " 0x%08x\n", cmd);
-    printf(COLOR_GREEN "Type Name: "COLOR_RESET"%s\n", get_load_command_name(cmd));
+    printf(COLOR_YELLOW "  [0x%08x] %s" COLOR_RESET, cmd, get_load_command_name(cmd));
     if (cmd & LC_REQ_DYLD)
-        printf("Note: This command requires dyld support (LC_REQ_DYLD set)\n");
+        printf(" (requires dyld)");
+    printf("\n");
 }
 
 void print_segment_flags(uint32_t flags)
 {
-    int x = 4;
     if (flags & SG_HIGHVM)
-        printf("%*s- SG_HIGHVM: File contents map to high VM space; low part is zero-filled.\n", x, "");
-
+        printf("      - SG_HIGHVM: file contents map to high VM space\n");
     if (flags & SG_FVMLIB)
-        printf("%*s- SG_FVMLIB: Segment allocated by a fixed VM library (used for overlap checking).\n", x, "");
-
+        printf("      - SG_FVMLIB: allocated by fixed VM library\n");
     if (flags & SG_NORELOC)
-        printf("%*s- SG_NORELOC: Segment has no relocations; safe to replace without relocation.\n", x, "");
-
+        printf("      - SG_NORELOC: no relocations\n");
     if (flags & SG_PROTECTED_VERSION_1)
-        printf("%*s- SG_PROTECTED_VERSION_1: Protected segment; only first page may be unprotected.\n", x, "");
-
+        printf("      - SG_PROTECTED_VERSION_1: protected segment\n");
     if (flags & SG_READ_ONLY)
-        printf("%*s- SG_READ_ONLY: Segment is made read-only after fixups.\n", x, "");
-
-    if (!(flags & (SG_HIGHVM | SG_FVMLIB | SG_NORELOC | SG_PROTECTED_VERSION_1 | SG_READ_ONLY)))
-        printf("%*s- No special segment flags set.\n", x, "");
+        printf("      - SG_READ_ONLY: read-only after fixups\n");
 }
 
-void print_macho_segment64_metadata(segment_command_64  *seg_cmd)
+/* =================== Metadata printers =================== */
+
+static void print_prot(uint32_t prot)
 {
-    printf(COLOR_GREEN "Segment Command (LC_SEGMENT_64):" COLOR_RESET "\n");
-    printf(COLOR_GREEN "  Segment Name:  " COLOR_RESET "%s\n", seg_cmd->segname);
-    printf(COLOR_GREEN "  VM Address:    " COLOR_RESET "0x%lx\n", seg_cmd->vmaddr);
-    printf(COLOR_GREEN "  VM Size:       " COLOR_RESET "0x%lx\n", seg_cmd->vmsize);
-    printf(COLOR_GREEN "  File Offset:   " COLOR_RESET "%lu\n", seg_cmd->fileoff);
-    printf(COLOR_GREEN "  File Size:     " COLOR_RESET "%lu\n", seg_cmd->filesize);
-    printf(COLOR_GREEN "  Max Prot:      " COLOR_RESET "0x%x\n", seg_cmd->maxprot);
-    printf(COLOR_GREEN "  Init Prot:     " COLOR_RESET "0x%x\n", seg_cmd->initprot);
-    printf(COLOR_GREEN "  Num Sections:  " COLOR_RESET "%u\n", seg_cmd->nsects);
-    printf(COLOR_GREEN "  Flags:         " COLOR_RESET "0x%x\n", seg_cmd->flags);
-    print_segment_flags(seg_cmd->flags);
+    printf("%c%c%c",
+        (prot & 1) ? 'r' : '-',
+        (prot & 2) ? 'w' : '-',
+        (prot & 4) ? 'x' : '-');
 }
 
-void print_macho_section64_metadata(section_64* sec_cmd)
+void print_macho_segment64_metadata(segment_command_64 *seg_cmd)
 {
-    printf(COLOR_GREEN "  Section name:"COLOR_RESET" %s\n", sec_cmd->sectname);
-    printf(COLOR_GREEN "  Segment name:"COLOR_RESET" %s\n" , sec_cmd->segname);
-    printf(COLOR_GREEN "  Memory Address:"COLOR_RESET" 0x%lx\n", sec_cmd->addr);
-    printf(COLOR_GREEN "  File Offset:"COLOR_RESET" 0x%x\n", sec_cmd->offset);
-    printf(COLOR_GREEN "  Size:"COLOR_RESET" %ld\n", sec_cmd->size);
-    printf(COLOR_GREEN "  Section Alignment(x**2):"COLOR_RESET" %d\n", sec_cmd->align);
-    printf(COLOR_GREEN "  File offset relocation entries:"COLOR_RESET" 0x%x\n", sec_cmd->reloff);
-    printf(COLOR_GREEN "  Number of relocation entries:"COLOR_RESET" %d\n" , sec_cmd->nreloc);
-    printf(COLOR_GREEN "  Flags:"COLOR_RESET" %x\n", sec_cmd->flags);
-    printf(COLOR_GREEN "  reserved for (offset or index):"COLOR_RESET" %d\n", sec_cmd->reserved1);	/* reserved (for offset or index) */
-    printf(COLOR_GREEN "  reserved for (count and sizeof):"COLOR_RESET" %d\n", sec_cmd->reserved2);	/* reserved (for count or sizeof) */
-    printf(COLOR_GREEN "  reserved: "COLOR_RESET"%d\n", sec_cmd->reserved3);	/* reserved */
+    printf(COLOR_GREEN "    Segment Name:  " COLOR_RESET "%-16s\n", seg_cmd->segname);
+    printf(COLOR_GREEN "    VM Address:    " COLOR_RESET "0x%016lx\n", (unsigned long)seg_cmd->vmaddr);
+    printf(COLOR_GREEN "    VM Size:       " COLOR_RESET "0x%lx (%lu bytes)\n", (unsigned long)seg_cmd->vmsize, (unsigned long)seg_cmd->vmsize);
+    printf(COLOR_GREEN "    File Offset:   " COLOR_RESET "0x%lx\n", (unsigned long)seg_cmd->fileoff);
+    printf(COLOR_GREEN "    File Size:     " COLOR_RESET "0x%lx (%lu bytes)\n", (unsigned long)seg_cmd->filesize, (unsigned long)seg_cmd->filesize);
+    printf(COLOR_GREEN "    Max Prot:      " COLOR_RESET);
+    print_prot(seg_cmd->maxprot); printf("\n");
+    printf(COLOR_GREEN "    Init Prot:     " COLOR_RESET);
+    print_prot(seg_cmd->initprot); printf("\n");
+    printf(COLOR_GREEN "    Num Sections:  " COLOR_RESET "%u\n", seg_cmd->nsects);
+    if (seg_cmd->flags)
+        print_segment_flags(seg_cmd->flags);
 }
 
-const char* platform_to_string(int platform) 
+void print_macho_segment32_metadata(segment_command *seg_cmd)
 {
-    switch (platform) {
-        case PLATFORM_MACOS: return "macOS";
-        case PLATFORM_IOS: return "iOS";
-        case PLATFORM_TVOS: return "tvOS";
-        case PLATFORM_WATCHOS: return "watchOS";
-        case PLATFORM_BRIDGEOS: return "bridgeOS";
-        case PLATFORM_MACCATALYST: return "Mac Catalyst";
-        case PLATFORM_IOSSIMULATOR: return "iOS Simulator";
-        case PLATFORM_TVOSSIMULATOR: return "tvOS Simulator";
-        case PLATFORM_WATCHOSSIMULATOR: return "watchOS Simulator";
-        case PLATFORM_DRIVERKIT: return "DriverKit";
-        default: return "Unknown Platform";
+    printf(COLOR_GREEN "    Segment Name:  " COLOR_RESET "%-16s\n", seg_cmd->segname);
+    printf(COLOR_GREEN "    VM Address:    " COLOR_RESET "0x%08x\n", seg_cmd->vmaddr);
+    printf(COLOR_GREEN "    VM Size:       " COLOR_RESET "0x%x (%u bytes)\n", seg_cmd->vmsize, seg_cmd->vmsize);
+    printf(COLOR_GREEN "    File Offset:   " COLOR_RESET "0x%x\n", seg_cmd->fileoff);
+    printf(COLOR_GREEN "    File Size:     " COLOR_RESET "0x%x (%u bytes)\n", seg_cmd->filesize, seg_cmd->filesize);
+    printf(COLOR_GREEN "    Max Prot:      " COLOR_RESET);
+    print_prot(seg_cmd->maxprot); printf("\n");
+    printf(COLOR_GREEN "    Init Prot:     " COLOR_RESET);
+    print_prot(seg_cmd->initprot); printf("\n");
+    printf(COLOR_GREEN "    Num Sections:  " COLOR_RESET "%u\n", seg_cmd->nsects);
+    if (seg_cmd->flags)
+        print_segment_flags(seg_cmd->flags);
+}
+
+void print_macho_section64_metadata(section_64 *s)
+{
+    printf(COLOR_CYAN "      %-16s" COLOR_RESET " %-16s  ", s->sectname, s->segname);
+    printf("addr=0x%016lx  size=0x%lx  offset=0x%x  align=2^%u",
+           (unsigned long)s->addr, (unsigned long)s->size, s->offset, s->align);
+    if (s->flags & S_ATTR_PURE_INSTRUCTIONS) printf("  " COLOR_RED "EXEC" COLOR_RESET);
+    printf("\n");
+}
+
+void print_macho_section32_metadata(section *s)
+{
+    printf(COLOR_CYAN "      %-16s" COLOR_RESET " %-16s  ", s->sectname, s->segname);
+    printf("addr=0x%08x  size=0x%x  offset=0x%x  align=2^%u",
+           s->addr, s->size, s->offset, s->align);
+    if (s->flags & S_ATTR_PURE_INSTRUCTIONS) printf("  " COLOR_RED "EXEC" COLOR_RESET);
+    printf("\n");
+}
+
+/* =================== Symbol table printers =================== */
+
+void print_macho_symbols_64(const unsigned char *block, size_t file_size,
+                            uint32_t symoff, uint32_t nsyms,
+                            uint32_t stroff, uint32_t strsize)
+{
+    if (symoff + (size_t)nsyms * sizeof(struct nlist_64) > file_size) {
+        fprintf(stderr, COLOR_RED "  [!] Symbol table extends beyond file bounds\n" COLOR_RESET);
+        return;
+    }
+    if (stroff + strsize > file_size) {
+        fprintf(stderr, COLOR_RED "  [!] String table extends beyond file bounds\n" COLOR_RESET);
+        return;
+    }
+
+    const struct nlist_64 *syms = (const struct nlist_64 *)(block + symoff);
+    const char *strs = (const char *)(block + stroff);
+
+    printf(COLOR_BLUE "\n  === Symbol Table (%u symbols) ===\n" COLOR_RESET, nsyms);
+    printf("  %-4s  %-18s  %-12s  %-8s  %s\n",
+           "Idx", "Value", "Type", "Section", "Name");
+    printf("  %-4s  %-18s  %-12s  %-8s  %s\n",
+           "---", "------------------", "------------", "--------", "----");
+
+    for (uint32_t i = 0; i < nsyms; i++) {
+        const char *name = "";
+        if (syms[i].n_strx < strsize)
+            name = strs + syms[i].n_strx;
+
+        const char *type_str = nlist_type_to_string(syms[i].n_type);
+        const char *sect_str = nlist_section_to_string(syms[i].n_sect);
+
+        /* Color external symbols differently */
+        const char *color = (syms[i].n_type & N_EXT) ? COLOR_GREEN : COLOR_RESET;
+
+        printf("  %-4u  %s0x%016lx" COLOR_RESET "  %-12s  %-8s  %s%s" COLOR_RESET "\n",
+               i, color, (unsigned long)syms[i].n_value,
+               type_str, sect_str, color, name);
     }
 }
 
-const char* tool_to_string(int tool) 
+void print_macho_symbols_32(const unsigned char *block, size_t file_size,
+                            uint32_t symoff, uint32_t nsyms,
+                            uint32_t stroff, uint32_t strsize)
+{
+    if (symoff + (size_t)nsyms * sizeof(struct nlist) > file_size) {
+        fprintf(stderr, COLOR_RED "  [!] Symbol table extends beyond file bounds\n" COLOR_RESET);
+        return;
+    }
+    if (stroff + strsize > file_size) {
+        fprintf(stderr, COLOR_RED "  [!] String table extends beyond file bounds\n" COLOR_RESET);
+        return;
+    }
+
+    const struct nlist *syms = (const struct nlist *)(block + symoff);
+    const char *strs = (const char *)(block + stroff);
+
+    printf(COLOR_BLUE "\n  === Symbol Table (%u symbols) ===\n" COLOR_RESET, nsyms);
+    printf("  %-4s  %-10s  %-12s  %-8s  %s\n",
+           "Idx", "Value", "Type", "Section", "Name");
+    printf("  %-4s  %-10s  %-12s  %-8s  %s\n",
+           "---", "----------", "------------", "--------", "----");
+
+    for (uint32_t i = 0; i < nsyms; i++) {
+        const char *name = "";
+        if (syms[i].n_strx < strsize)
+            name = strs + syms[i].n_strx;
+
+        const char *type_str = nlist_type_to_string(syms[i].n_type);
+        const char *sect_str = nlist_section_to_string(syms[i].n_sect);
+        const char *color = (syms[i].n_type & N_EXT) ? COLOR_GREEN : COLOR_RESET;
+
+        printf("  %-4u  %s0x%08x" COLOR_RESET "  %-12s  %-8s  %s%s" COLOR_RESET "\n",
+               i, color, syms[i].n_value,
+               type_str, sect_str, color, name);
+    }
+}
+
+/* =================== Version / UUID decoders =================== */
+
+void print_tool_version(uint32_t version)
+{
+    printf("%u.%u.%u",
+           (version >> 16) & 0xffff,
+           (version >> 8) & 0xff,
+           version & 0xff);
+}
+
+void print_version_xyz(uint32_t version)
+{
+    printf("%u.%u.%u",
+           (version >> 16) & 0xffff,
+           (version >> 8) & 0xff,
+           version & 0xff);
+}
+
+void print_uuid(const uint8_t uuid[16])
+{
+    printf("%02X%02X%02X%02X-%02X%02X-%02X%02X-%02X%02X-%02X%02X%02X%02X%02X%02X",
+        uuid[0], uuid[1], uuid[2], uuid[3],
+        uuid[4], uuid[5], uuid[6], uuid[7],
+        uuid[8], uuid[9], uuid[10], uuid[11],
+        uuid[12], uuid[13], uuid[14], uuid[15]);
+}
+
+void print_source_version(uint64_t packed_version)
+{
+    uint64_t A = (packed_version >> 40) & 0xFFFFFF;
+    uint64_t B = (packed_version >> 30) & 0x3FF;
+    uint64_t C = (packed_version >> 20) & 0x3FF;
+    uint64_t D = (packed_version >> 10) & 0x3FF;
+    uint64_t E =  packed_version        & 0x3FF;
+    printf("%lu.%lu.%lu.%lu.%lu", A, B, C, D, E);
+}
+
+const char* platform_to_string(int platform)
+{
+    switch (platform) {
+        case PLATFORM_MACOS:              return "macOS";
+        case PLATFORM_IOS:                return "iOS";
+        case PLATFORM_TVOS:               return "tvOS";
+        case PLATFORM_WATCHOS:            return "watchOS";
+        case PLATFORM_BRIDGEOS:           return "bridgeOS";
+        case PLATFORM_MACCATALYST:        return "Mac Catalyst";
+        case PLATFORM_IOSSIMULATOR:       return "iOS Simulator";
+        case PLATFORM_TVOSSIMULATOR:      return "tvOS Simulator";
+        case PLATFORM_WATCHOSSIMULATOR:   return "watchOS Simulator";
+        case PLATFORM_DRIVERKIT:          return "DriverKit";
+        default:                          return "Unknown Platform";
+    }
+}
+
+const char* tool_to_string(int tool)
 {
     switch (tool) {
         case TOOL_CLANG: return "Clang";
@@ -202,37 +409,35 @@ const char* tool_to_string(int tool)
     }
 }
 
-/* Helper to decode version numbers (e.g. 0x0e050000 → 14.5.0) */
-void print_tool_version(uint32_t version)
+/* =================== Section attribute helpers =================== */
+
+bool macho_section_is_executable(uint32_t flags)
 {
-    printf("%u.%u.%u",
-           (version >> 16) & 0xffff,
-           (version >> 8) & 0xff,
-           version & 0xff);
+    return (flags & S_ATTR_PURE_INSTRUCTIONS) || (flags & S_ATTR_SOME_INSTRUCTIONS);
 }
 
-
-/* Helper to decode uuid 128 bit*/
-void print_uuid(const uint8_t uuid[16]) 
+const char* macho_section_type_to_string(uint32_t flags)
 {
-    printf("%02X%02X%02X%02X-%02X%02X-%02X%02X-%02X%02X-%02X%02X%02X%02X%02X%02X",
-        uuid[0], uuid[1], uuid[2], uuid[3],
-        uuid[4], uuid[5],
-        uuid[6], uuid[7],
-        uuid[8], uuid[9],
-        uuid[10], uuid[11], uuid[12], uuid[13], uuid[14], uuid[15]);
+    switch (flags & SECTION_TYPE) {
+        case S_REGULAR:                    return "S_REGULAR";
+        case S_ZEROFILL:                   return "S_ZEROFILL";
+        case S_CSTRING_LITERALS:           return "S_CSTRING_LITERALS";
+        case S_4BYTE_LITERALS:             return "S_4BYTE_LITERALS";
+        case S_8BYTE_LITERALS:             return "S_8BYTE_LITERALS";
+        case S_LITERAL_POINTERS:           return "S_LITERAL_POINTERS";
+        case S_NON_LAZY_SYMBOL_POINTERS:   return "S_NON_LAZY_SYMBOL_POINTERS";
+        case S_LAZY_SYMBOL_POINTERS:       return "S_LAZY_SYMBOL_POINTERS";
+        case S_SYMBOL_STUBS:               return "S_SYMBOL_STUBS";
+        case S_MOD_INIT_FUNC_POINTERS:     return "S_MOD_INIT_FUNC_POINTERS";
+        case S_MOD_TERM_FUNC_POINTERS:     return "S_MOD_TERM_FUNC_POINTERS";
+        case S_COALESCED:                  return "S_COALESCED";
+        case S_GB_ZEROFILL:                return "S_GB_ZEROFILL";
+        case S_INTERPOSING:                return "S_INTERPOSING";
+        case S_16BYTE_LITERALS:            return "S_16BYTE_LITERALS";
+        case S_DTRACE_DOF:                 return "S_DTRACE_DOF";
+        case S_THREAD_LOCAL_REGULAR:       return "S_THREAD_LOCAL_REGULAR";
+        case S_THREAD_LOCAL_ZEROFILL:      return "S_THREAD_LOCAL_ZEROFILL";
+        case S_THREAD_LOCAL_VARIABLES:     return "S_THREAD_LOCAL_VARIABLES";
+        default:                           return "UNKNOWN";
+    }
 }
-
-/* Helper to decode source version */
-void print_source_version(uint64_t packed_version) 
-{
-    uint64_t A = (packed_version >> 40) & 0xFFFFFF;  // top 24 bits
-    uint64_t B = (packed_version >> 30) & 0x3FF;
-    uint64_t C = (packed_version >> 20) & 0x3FF;
-    uint64_t D = (packed_version >> 10) & 0x3FF;
-    uint64_t E =  packed_version        & 0x3FF;
-    printf("%lu.%lu.%lu.%lu.%lu",  A, B, C, D, E);
-}
-
-
-

--- a/modules/bx_macho_utils/bx_macho_utils.h
+++ b/modules/bx_macho_utils/bx_macho_utils.h
@@ -1,25 +1,62 @@
+/**
+ * @file bx_macho_utils.h
+ * @brief Utility functions for Mach-O binary analysis.
+ *
+ * Provides human-readable string conversion, pretty-printing, and
+ * helper routines for Mach-O headers, load commands, segments,
+ * sections, symbols, and version decoding.
+ */
 #ifndef BX_MACHO_UTILS
 #define BX_MACHO_UTILS
+
 #include <stdint.h>
+#include <stddef.h>
+#include <stdbool.h>
 #include "macho.h"
 
-// Helper functions for convert enums to actual meaning ...
+/* =================== Type-to-string conversions =================== */
+
 const char* get_mach_o_type(unsigned int type);
-void print_mach_o_flags(unsigned int flags);
 const char* get_load_command_name(uint32_t cmd);
-void print_load_command_info(uint32_t cmd);
-void print_segment_flags(uint32_t flags);
 const char* platform_to_string(int platform);
 const char* tool_to_string(int tool);
+const char* cpu_type_to_string(cpu_type_t cputype);
+const char* cpu_subtype_to_string(cpu_type_t cputype, cpu_subtype_t cpusubtype);
+const char* nlist_type_to_string(uint8_t n_type);
+const char* nlist_section_to_string(uint8_t n_sect);
 
-// Helper functions for decode and print stuff...
+/* =================== Flag / field printers =================== */
+
+void print_mach_o_flags(unsigned int flags);
+void print_load_command_info(uint32_t cmd);
+void print_segment_flags(uint32_t flags);
+
+/* =================== Metadata printers =================== */
+
+void print_macho_segment64_metadata(segment_command_64 *seg_cmd);
+void print_macho_segment32_metadata(segment_command *seg_cmd);
+void print_macho_section64_metadata(section_64 *sec_cmd);
+void print_macho_section32_metadata(section *sec_cmd);
+
+/* =================== Symbol table printers =================== */
+
+void print_macho_symbols_64(const unsigned char *block, size_t file_size,
+                            uint32_t symoff, uint32_t nsyms,
+                            uint32_t stroff, uint32_t strsize);
+void print_macho_symbols_32(const unsigned char *block, size_t file_size,
+                            uint32_t symoff, uint32_t nsyms,
+                            uint32_t stroff, uint32_t strsize);
+
+/* =================== Version / UUID decoders =================== */
+
 void print_tool_version(uint32_t version);
 void print_uuid(const uint8_t uuid[16]);
 void print_source_version(uint64_t packed_version);
+void print_version_xyz(uint32_t version);
 
-// print metadata
-void print_macho_segment64_metadata(segment_command_64  *seg_cmd);
-void print_macho_section64_metadata(section_64* sec_cmd);
+/* =================== Section attribute helpers =================== */
 
-#endif 
+bool macho_section_is_executable(uint32_t flags);
+const char* macho_section_type_to_string(uint32_t flags);
 
+#endif /* BX_MACHO_UTILS */

--- a/tests/test_baseer_core.c
+++ b/tests/test_baseer_core.c
@@ -1,0 +1,149 @@
+/**
+ * @file test_baseer_core.c
+ * @brief Unit tests for baseer core (open, close, execute).
+ */
+#include "test_framework.h"
+#include "../baseer.h"
+
+/* We need a real file for testing. Use the test binary from examples/ */
+#define TEST_ELF_64 "examples/64bit_x86_64_gcc"
+#define TEST_ELF_32 "examples/32bit_x86_gcc"
+
+TEST(test_open_null_path) {
+    baseer_target_t *t = baseer_open(NULL, BASEER_MODE_MEMORY);
+    ASSERT_NULL(t);
+}
+
+TEST(test_open_nonexistent_file) {
+    baseer_target_t *t = baseer_open("/nonexistent/path/file", BASEER_MODE_MEMORY);
+    ASSERT_NULL(t);
+}
+
+TEST(test_open_memory_mode) {
+    baseer_target_t *t = baseer_open(TEST_ELF_64, BASEER_MODE_MEMORY);
+    if (!t) {
+        /* Skip if test binary not available */
+        printf("(skipped - no test binary) ");
+        return;
+    }
+    ASSERT_NOT_NULL(t);
+    ASSERT_NOT_NULL(t->block);
+    ASSERT_NULL(t->fp); /* memory mode should not keep fp open */
+    ASSERT(t->size > 0);
+    ASSERT_EQ(t->mode, BASEER_MODE_MEMORY);
+    baseer_close(t);
+}
+
+TEST(test_open_stream_mode) {
+    baseer_target_t *t = baseer_open(TEST_ELF_64, BASEER_MODE_STREAM);
+    if (!t) {
+        printf("(skipped - no test binary) ");
+        return;
+    }
+    ASSERT_NOT_NULL(t);
+    ASSERT_NOT_NULL(t->fp);
+    ASSERT(t->size > 0);
+    ASSERT_EQ(t->mode, BASEER_MODE_STREAM);
+    baseer_close(t);
+}
+
+TEST(test_open_both_mode) {
+    baseer_target_t *t = baseer_open(TEST_ELF_64, BASEER_MODE_BOTH);
+    if (!t) {
+        printf("(skipped - no test binary) ");
+        return;
+    }
+    ASSERT_NOT_NULL(t);
+    ASSERT_NOT_NULL(t->block);
+    ASSERT_NOT_NULL(t->fp);
+    ASSERT(t->size > 0);
+    ASSERT_EQ(t->mode, BASEER_MODE_BOTH);
+    baseer_close(t);
+}
+
+TEST(test_close_null) {
+    /* Should not crash */
+    baseer_close(NULL);
+}
+
+static bool dummy_callback(baseer_target_t *target, void *arg) {
+    *(int*)arg = 1;
+    return true;
+}
+
+static bool failing_callback(baseer_target_t *target, void *arg) {
+    return false;
+}
+
+TEST(test_execute_null_target) {
+    int val = 0;
+    bool result = baseer_execute(NULL, dummy_callback, &val);
+    ASSERT_EQ(result, false);
+    ASSERT_EQ(val, 0); /* callback should not have been called */
+}
+
+TEST(test_execute_null_callback) {
+    baseer_target_t *t = baseer_open(TEST_ELF_64, BASEER_MODE_MEMORY);
+    if (!t) {
+        printf("(skipped - no test binary) ");
+        return;
+    }
+    bool result = baseer_execute(t, NULL, NULL);
+    ASSERT_EQ(result, false);
+    baseer_close(t);
+}
+
+TEST(test_execute_success) {
+    baseer_target_t *t = baseer_open(TEST_ELF_64, BASEER_MODE_MEMORY);
+    if (!t) {
+        printf("(skipped - no test binary) ");
+        return;
+    }
+    int val = 0;
+    bool result = baseer_execute(t, dummy_callback, &val);
+    ASSERT_EQ(result, true);
+    ASSERT_EQ(val, 1);
+    baseer_close(t);
+}
+
+TEST(test_execute_failure) {
+    baseer_target_t *t = baseer_open(TEST_ELF_64, BASEER_MODE_MEMORY);
+    if (!t) {
+        printf("(skipped - no test binary) ");
+        return;
+    }
+    bool result = baseer_execute(t, failing_callback, NULL);
+    ASSERT_EQ(result, false);
+    baseer_close(t);
+}
+
+TEST(test_elf_magic_bytes) {
+    baseer_target_t *t = baseer_open(TEST_ELF_64, BASEER_MODE_MEMORY);
+    if (!t) {
+        printf("(skipped - no test binary) ");
+        return;
+    }
+    unsigned char *data = (unsigned char*)t->block;
+    /* ELF magic: 0x7f 'E' 'L' 'F' */
+    ASSERT_EQ(data[0], 0x7f);
+    ASSERT_EQ(data[1], 'E');
+    ASSERT_EQ(data[2], 'L');
+    ASSERT_EQ(data[3], 'F');
+    baseer_close(t);
+}
+
+int main(void) {
+    printf("\n=== Baseer Core Tests ===\n");
+    RUN_TEST(test_open_null_path);
+    RUN_TEST(test_open_nonexistent_file);
+    RUN_TEST(test_open_memory_mode);
+    RUN_TEST(test_open_stream_mode);
+    RUN_TEST(test_open_both_mode);
+    RUN_TEST(test_close_null);
+    RUN_TEST(test_execute_null_target);
+    RUN_TEST(test_execute_null_callback);
+    RUN_TEST(test_execute_success);
+    RUN_TEST(test_execute_failure);
+    RUN_TEST(test_elf_magic_bytes);
+    TEST_REPORT();
+}

--- a/tests/test_bparser.c
+++ b/tests/test_bparser.c
@@ -1,0 +1,124 @@
+/**
+ * @file test_bparser.c
+ * @brief Unit tests for the bparser module.
+ */
+#include "test_framework.h"
+#include "../modules/bparser/bparser.h"
+
+#define TEST_ELF_64 "examples/64bit_x86_64_gcc"
+
+TEST(test_bparser_load_null) {
+    bparser *bp = bparser_load(NULL);
+    ASSERT_NULL(bp);
+}
+
+TEST(test_bparser_load_valid) {
+    baseer_target_t *t = baseer_open(TEST_ELF_64, BASEER_MODE_BOTH);
+    if (!t) {
+        printf("(skipped - no test binary) ");
+        return;
+    }
+    bparser *bp = bparser_load(t);
+    ASSERT_NOT_NULL(bp);
+    ASSERT_EQ(bp->mode, BASEER_MODE_BOTH);
+    ASSERT_NOT_NULL(bp->block);
+    ASSERT_NOT_NULL(bp->fp);
+    ASSERT(bp->size > 0);
+    ASSERT_EQ(bp->size, t->size);
+    free(bp);
+    baseer_close(t);
+}
+
+TEST(test_bparser_read_memory) {
+    baseer_target_t *t = baseer_open(TEST_ELF_64, BASEER_MODE_MEMORY);
+    if (!t) {
+        printf("(skipped - no test binary) ");
+        return;
+    }
+    bparser *bp = bparser_load(t);
+    ASSERT_NOT_NULL(bp);
+
+    unsigned char buf[4] = {0};
+    size_t n = bparser_read(bp, buf, 0, 4);
+    ASSERT_EQ(n, 4);
+    /* ELF magic */
+    ASSERT_EQ(buf[0], 0x7f);
+    ASSERT_EQ(buf[1], 'E');
+    ASSERT_EQ(buf[2], 'L');
+    ASSERT_EQ(buf[3], 'F');
+
+    free(bp);
+    baseer_close(t);
+}
+
+TEST(test_bparser_read_null_params) {
+    size_t n = bparser_read(NULL, NULL, 0, 4);
+    ASSERT_EQ(n, 0);
+}
+
+TEST(test_bparser_read_beyond_bounds) {
+    baseer_target_t *t = baseer_open(TEST_ELF_64, BASEER_MODE_MEMORY);
+    if (!t) {
+        printf("(skipped - no test binary) ");
+        return;
+    }
+    bparser *bp = bparser_load(t);
+
+    unsigned char buf[16] = {0};
+    /* Read from beyond the file size */
+    size_t n = bparser_read(bp, buf, bp->size + 100, 16);
+    /* Should return the file size (bounds check) */
+    ASSERT_EQ(n, bp->size);
+
+    free(bp);
+    baseer_close(t);
+}
+
+static bool test_callback_ran = false;
+static bool test_cb(bparser *p, void *arg) {
+    test_callback_ran = true;
+    return true;
+}
+
+TEST(test_bparser_apply) {
+    baseer_target_t *t = baseer_open(TEST_ELF_64, BASEER_MODE_MEMORY);
+    if (!t) {
+        printf("(skipped - no test binary) ");
+        return;
+    }
+    bparser *bp = bparser_load(t);
+    test_callback_ran = false;
+    bool result = bparser_apply(bp, test_cb, NULL);
+    ASSERT_EQ(result, 1);
+    ASSERT_EQ(test_callback_ran, true);
+    free(bp);
+    baseer_close(t);
+}
+
+TEST(test_bparser_apply_null) {
+    bool result = bparser_apply(NULL, test_cb, NULL);
+    ASSERT_EQ(result, 0);
+
+    baseer_target_t *t = baseer_open(TEST_ELF_64, BASEER_MODE_MEMORY);
+    if (!t) {
+        printf("(skipped - no test binary) ");
+        return;
+    }
+    bparser *bp = bparser_load(t);
+    result = bparser_apply(bp, NULL, NULL);
+    ASSERT_EQ(result, 0);
+    free(bp);
+    baseer_close(t);
+}
+
+int main(void) {
+    printf("\n=== BParser Tests ===\n");
+    RUN_TEST(test_bparser_load_null);
+    RUN_TEST(test_bparser_load_valid);
+    RUN_TEST(test_bparser_read_memory);
+    RUN_TEST(test_bparser_read_null_params);
+    RUN_TEST(test_bparser_read_beyond_bounds);
+    RUN_TEST(test_bparser_apply);
+    RUN_TEST(test_bparser_apply_null);
+    TEST_REPORT();
+}

--- a/tests/test_framework.h
+++ b/tests/test_framework.h
@@ -1,0 +1,57 @@
+/**
+ * @file test_framework.h
+ * @brief Minimal single-header unit test framework for Baseer.
+ *
+ * Usage:
+ *   #include "test_framework.h"
+ *   TEST(test_name) { ASSERT(1 == 1); }
+ *   int main(void) { RUN_TEST(test_name); TEST_REPORT(); }
+ */
+#ifndef TEST_FRAMEWORK_H
+#define TEST_FRAMEWORK_H
+
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+
+static int _tf_pass = 0;
+static int _tf_fail = 0;
+static int _tf_total = 0;
+
+#define TEST(name) static void name(void)
+
+#define RUN_TEST(name) do { \
+    _tf_total++; \
+    printf("  [RUN ] %s ... ", #name); \
+    fflush(stdout); \
+    name(); \
+    _tf_pass++; \
+    printf("\033[32mPASS\033[0m\n"); \
+} while(0)
+
+/* If an assertion fails, longjmp is overkill; just print and exit the test */
+#define ASSERT(cond) do { \
+    if (!(cond)) { \
+        printf("\033[31mFAIL\033[0m\n"); \
+        fprintf(stderr, "    Assertion failed: %s\n    at %s:%d\n", #cond, __FILE__, __LINE__); \
+        _tf_fail++; \
+        _tf_pass--; /* undo the pre-increment in RUN_TEST */ \
+        return; \
+    } \
+} while(0)
+
+#define ASSERT_EQ(a, b) ASSERT((a) == (b))
+#define ASSERT_NEQ(a, b) ASSERT((a) != (b))
+#define ASSERT_NULL(p) ASSERT((p) == NULL)
+#define ASSERT_NOT_NULL(p) ASSERT((p) != NULL)
+#define ASSERT_STR_EQ(a, b) ASSERT(strcmp((a), (b)) == 0)
+
+#define TEST_REPORT() do { \
+    printf("\n  ================================\n"); \
+    printf("  Results: %d/%d passed", _tf_pass, _tf_total); \
+    if (_tf_fail > 0) printf(", \033[31m%d failed\033[0m", _tf_fail); \
+    printf("\n  ================================\n"); \
+    return (_tf_fail > 0) ? 1 : 0; \
+} while(0)
+
+#endif /* TEST_FRAMEWORK_H */

--- a/tests/test_hashmap.c
+++ b/tests/test_hashmap.c
@@ -1,0 +1,91 @@
+/**
+ * @file test_hashmap.c
+ * @brief Unit tests for the b_hashmap module.
+ */
+#include "test_framework.h"
+#include "../modules/b_hashmap/b_hashmap.h"
+
+TEST(test_create_map) {
+    hashmap_t *map = create_map();
+    ASSERT_NOT_NULL(map);
+    for (int i = 0; i < TABLE_SIZE; i++) {
+        ASSERT_NULL(map->buckets[i]);
+    }
+    free_map(map);
+}
+
+TEST(test_insert_and_get) {
+    hashmap_t *map = create_map();
+    int val1 = 42;
+    int val2 = 99;
+    insert(map, "key1", &val1);
+    insert(map, "key2", &val2);
+
+    void *result1 = get(map, "key1");
+    void *result2 = get(map, "key2");
+    ASSERT_NOT_NULL(result1);
+    ASSERT_NOT_NULL(result2);
+    ASSERT_EQ(*(int*)result1, 42);
+    ASSERT_EQ(*(int*)result2, 99);
+    free_map(map);
+}
+
+TEST(test_get_nonexistent) {
+    hashmap_t *map = create_map();
+    void *result = get(map, "nonexistent");
+    ASSERT_NULL(result);
+    free_map(map);
+}
+
+TEST(test_hash_collision_handling) {
+    hashmap_t *map = create_map();
+    /* Insert many keys to exercise collision chains */
+    int values[50];
+    char keys[50][16];
+    for (int i = 0; i < 50; i++) {
+        values[i] = i * 10;
+        snprintf(keys[i], sizeof(keys[i]), "key_%d", i);
+        insert(map, keys[i], &values[i]);
+    }
+    /* Verify all can be retrieved */
+    for (int i = 0; i < 50; i++) {
+        void *result = get(map, keys[i]);
+        ASSERT_NOT_NULL(result);
+        ASSERT_EQ(*(int*)result, i * 10);
+    }
+    free_map(map);
+}
+
+TEST(test_duplicate_key_insert) {
+    hashmap_t *map = create_map();
+    int val1 = 10;
+    int val2 = 20;
+    insert(map, "dup", &val1);
+    insert(map, "dup", &val2);
+    /* Should return the most recently inserted (head of chain) */
+    void *result = get(map, "dup");
+    ASSERT_NOT_NULL(result);
+    ASSERT_EQ(*(int*)result, 20);
+    free_map(map);
+}
+
+TEST(test_empty_key) {
+    hashmap_t *map = create_map();
+    int val = 7;
+    insert(map, "", &val);
+    void *result = get(map, "");
+    ASSERT_NOT_NULL(result);
+    ASSERT_EQ(*(int*)result, 7);
+    free_map(map);
+}
+
+int main(void) {
+    printf("\n=== Hashmap Tests ===\n");
+    RUN_TEST(test_create_map);
+    RUN_TEST(test_insert_and_get);
+    RUN_TEST(test_get_nonexistent);
+    RUN_TEST(test_hash_collision_handling);
+    RUN_TEST(test_duplicate_key_insert);
+    RUN_TEST(test_empty_key);
+    TEST_REPORT();
+}

--- a/tests/test_macho.c
+++ b/tests/test_macho.c
@@ -1,0 +1,113 @@
+/**
+ * @file test_macho.c
+ * @brief Unit tests for Mach-O parsing modules.
+ */
+#include "test_framework.h"
+#include <stdint.h>
+#include "../baseer.h"
+#include "../modules/bparser/bparser.h"
+
+#define TEST_MACHO "examples/macho"
+
+TEST(test_macho_file_opens) {
+    baseer_target_t *t = baseer_open(TEST_MACHO, BASEER_MODE_MEMORY);
+    if (!t) {
+        printf("(skipped - no test binary) ");
+        return;
+    }
+    ASSERT_NOT_NULL(t);
+    ASSERT_NOT_NULL(t->block);
+    ASSERT(t->size > 0);
+    baseer_close(t);
+}
+
+TEST(test_macho_magic_64) {
+    baseer_target_t *t = baseer_open(TEST_MACHO, BASEER_MODE_MEMORY);
+    if (!t) {
+        printf("(skipped - no test binary) ");
+        return;
+    }
+    unsigned char *data = (unsigned char *)t->block;
+    /* Mach-O 64-bit magic: 0xFEEDFACF (little-endian: CF FA ED FE) */
+    uint32_t magic = *(uint32_t *)data;
+    ASSERT(magic == 0xfeedface || magic == 0xfeedfacf);
+    baseer_close(t);
+}
+
+TEST(test_macho_header_size) {
+    baseer_target_t *t = baseer_open(TEST_MACHO, BASEER_MODE_MEMORY);
+    if (!t) {
+        printf("(skipped - no test binary) ");
+        return;
+    }
+    /* A valid Mach-O must be at least 28 bytes (32-bit header size) */
+    ASSERT(t->size >= 28);
+    baseer_close(t);
+}
+
+TEST(test_macho_ncmds_sane) {
+    baseer_target_t *t = baseer_open(TEST_MACHO, BASEER_MODE_MEMORY);
+    if (!t) {
+        printf("(skipped - no test binary) ");
+        return;
+    }
+    unsigned char *data = (unsigned char *)t->block;
+    uint32_t magic = *(uint32_t *)data;
+
+    uint32_t ncmds;
+    if (magic == 0xfeedfacf) {
+        /* 64-bit: ncmds at offset 16 */
+        ncmds = *(uint32_t *)(data + 16);
+    } else {
+        /* 32-bit: ncmds at offset 12 */
+        ncmds = *(uint32_t *)(data + 12);
+    }
+    /* Should be a reasonable number */
+    ASSERT(ncmds > 0);
+    ASSERT(ncmds < 10000);
+    baseer_close(t);
+}
+
+TEST(test_macho_bparser_load) {
+    baseer_target_t *t = baseer_open(TEST_MACHO, BASEER_MODE_BOTH);
+    if (!t) {
+        printf("(skipped - no test binary) ");
+        return;
+    }
+    bparser *bp = bparser_load(t);
+    ASSERT_NOT_NULL(bp);
+    ASSERT_EQ(bp->size, t->size);
+
+    /* Read first 4 bytes through bparser */
+    unsigned char buf[4] = {0};
+    size_t n = bparser_read(bp, buf, 0, 4);
+    ASSERT_EQ(n, 4);
+    /* Should match Mach-O magic */
+    uint32_t magic = *(uint32_t *)buf;
+    ASSERT(magic == 0xfeedface || magic == 0xfeedfacf);
+
+    free(bp);
+    baseer_close(t);
+}
+
+TEST(test_macho_too_small_rejected) {
+    /* Create a tiny file that's too small to be a Mach-O */
+    /* We test the NULL/size checks in baseer_open with a nonexistent path */
+    baseer_target_t *t = baseer_open("/dev/null", BASEER_MODE_MEMORY);
+    /* /dev/null has 0 bytes - should either fail or produce a 0-size target */
+    if (t) {
+        ASSERT_EQ(t->size, 0);
+        baseer_close(t);
+    }
+}
+
+int main(void) {
+    printf("\n=== Mach-O Tests ===\n");
+    RUN_TEST(test_macho_file_opens);
+    RUN_TEST(test_macho_magic_64);
+    RUN_TEST(test_macho_header_size);
+    RUN_TEST(test_macho_ncmds_sane);
+    RUN_TEST(test_macho_bparser_load);
+    RUN_TEST(test_macho_too_small_rejected);
+    TEST_REPORT();
+}

--- a/utils/b_CLI.c
+++ b/utils/b_CLI.c
@@ -63,7 +63,6 @@ void baseer_CLI(void) {
     int cli_argc = 3;
     char *cli_args[4] = {"baseer", NULL, NULL, NULL};
     inputs input = {&cli_argc, cli_args};
-    // create hashmap of any hashmaps needed by baseer extentions to used it for other extentions...
     input.map = create_map();
     linenoiseSetCompletionCallback(completion);
 
@@ -94,6 +93,7 @@ void baseer_CLI(void) {
             char *fname = line + 5;
             if (target){
                 printf(COLOR_RED"[!] There is a file already open. Use 'close' first.\n"COLOR_RESET);
+                free(line);
                 continue;
             } else {
                 target = baseer_open(fname, BASEER_MODE_BOTH);
@@ -103,12 +103,14 @@ void baseer_CLI(void) {
         } else if (strcmp(line, "stored-args") == 0) {
             if (input.input_argc == 0) {
                 printf(COLOR_YELLOW"[!] No arguments stored.\n"COLOR_RESET);
+                free(line);
                 continue;
             } else {
                 printf("Stored arguments:\n");
                 for (int i = 0; i < input.input_argc; i++) {
                     printf("  [%d] %s\n", i, input.input_args[i]);
                 }
+                free(line);
                 continue;
             }
         } else if (strncmp(line, "metadata", 8) == 0) {
@@ -116,10 +118,12 @@ void baseer_CLI(void) {
             cli_args[2] = "-m";
             if (!target){
                 printf(COLOR_RED"[!] No file opened. use 'open <file>' first.\n"COLOR_RESET);
+                free(line);
                 continue;
             }
             if (!baseer_execute(target, bx_binhead, &input)) {
                 fprintf(stderr, "[!] Execution error\n");
+                free(line);
                 continue;
             }
         } else if (strncmp(line, "disassembler", 12) == 0) {
@@ -127,10 +131,12 @@ void baseer_CLI(void) {
             cli_args[2] = "-a";
             if (!target){
                 printf(COLOR_RED"[!] No file opened. use 'open <file>' first.\n"COLOR_RESET);
+                free(line);
                 continue;
             }
             if (!baseer_execute(target, bx_binhead, &input)) {
                 fprintf(stderr, "[!] Execution error\n");
+                free(line);
                 continue;
             }
         } else if (strncmp(line, "decompiler", 10) == 0) {
@@ -138,10 +144,12 @@ void baseer_CLI(void) {
             cli_args[2] = "-c";
             if (!target){
                 printf(COLOR_RED"[!] No file opened. use 'open <file>' first.\n"COLOR_RESET);
+                free(line);
                 continue;
             }
             if (!baseer_execute(target, bx_binhead, &input)) {
                 fprintf(stderr, "[!] Execution error\n");
+                free(line);
                 continue;
             }
         } else if (strncmp(line, "debugger", 8) == 0) {
@@ -149,14 +157,21 @@ void baseer_CLI(void) {
             cli_args[2] = "-d";
             if (!target){
                 printf(COLOR_RED"[!] No file opened. use 'open <file>' first.\n"COLOR_RESET);
+                free(line);
                 continue;
             }
             if (!baseer_execute(target, bx_binhead, &input)) {
                 fprintf(stderr, "[!] Execution error\n");
+                free(line);
                 continue;
             }
         } else if (strncmp(line, "args ", 5) == 0) {
             char *argline = line + 5;
+            // Free previously stored args before overwriting
+            for (int i = 0; i < input.input_argc; i++) {
+                free(input.input_args[i]);
+                input.input_args[i] = NULL;
+            }
             input.input_argc = 0;
 
             char *tok = strtok(argline, " ");
@@ -167,11 +182,13 @@ void baseer_CLI(void) {
             }
             if (input.input_argc == 0) {
                 printf(COLOR_RED"[!] No arguments entered.\n"COLOR_RESET);
+                free(line);
                 continue;
              } else {
                 for (int i = 0; i < input.input_argc; i++) {
                     printf("  [%d] %s\n", i, input.input_args[i]);
                 }
+                free(line);
                 continue;
             }
         } else if (strcmp(line, "close") == 0) {
@@ -179,15 +196,22 @@ void baseer_CLI(void) {
                 baseer_close(target);
                 target = NULL;
                 printf("Closed.\n");
+                free(line);
                 continue;
             } else {
                 printf(COLOR_YELLOW"[!] No file is currently open.\n"COLOR_RESET);
+                free(line);
                 continue;
             }
         } else {
             printf(COLOR_YELLOW"Unknown command: %s\n"COLOR_RESET, line);
         }
         free(line);
+    }
+    // Free stored args on exit
+    for (int i = 0; i < input.input_argc; i++) {
+        free(input.input_args[i]);
+        input.input_args[i] = NULL;
     }
     if (target){
         free_map(input.map);

--- a/utils/b_log.h
+++ b/utils/b_log.h
@@ -1,0 +1,68 @@
+/**
+ * @file b_log.h
+ * @brief Centralized logging macros for Baseer.
+ *
+ * Provides leveled logging (DEBUG, INFO, WARN, ERROR) with color-coded
+ * output and optional verbose mode controlled by the BASEER_VERBOSE
+ * environment variable.
+ *
+ * Usage:
+ *   LOG_ERROR("failed to open file: %s", path);
+ *   LOG_WARN("section offset out of bounds");
+ *   LOG_INFO("loaded %d symbols", count);
+ *   LOG_DEBUG("parsing section %d", i);
+ */
+#ifndef B_LOG_H
+#define B_LOG_H
+
+#include <stdio.h>
+#include <stdlib.h>
+
+/**
+ * @brief Log levels
+ */
+typedef enum {
+    BASEER_LOG_ERROR = 0,
+    BASEER_LOG_WARN  = 1,
+    BASEER_LOG_INFO  = 2,
+    BASEER_LOG_DEBUG = 3,
+} baseer_log_level_t;
+
+/**
+ * @brief Get the current log level from environment.
+ *
+ * Controlled by BASEER_LOG_LEVEL env var:
+ *   0 = errors only
+ *   1 = + warnings
+ *   2 = + info (default)
+ *   3 = + debug
+ */
+static inline int baseer_log_level(void) {
+    const char *env = getenv("BASEER_LOG_LEVEL");
+    if (env) {
+        int val = atoi(env);
+        if (val >= 0 && val <= 3) return val;
+    }
+    return BASEER_LOG_INFO; /* default: show errors, warnings, info */
+}
+
+#define LOG_ERROR(fmt, ...) do { \
+    fprintf(stderr, "\033[31m[ERROR]\033[0m " fmt "\n", ##__VA_ARGS__); \
+} while(0)
+
+#define LOG_WARN(fmt, ...) do { \
+    if (baseer_log_level() >= BASEER_LOG_WARN) \
+        fprintf(stderr, "\033[33m[WARN]\033[0m  " fmt "\n", ##__VA_ARGS__); \
+} while(0)
+
+#define LOG_INFO(fmt, ...) do { \
+    if (baseer_log_level() >= BASEER_LOG_INFO) \
+        printf("\033[34m[INFO]\033[0m  " fmt "\n", ##__VA_ARGS__); \
+} while(0)
+
+#define LOG_DEBUG(fmt, ...) do { \
+    if (baseer_log_level() >= BASEER_LOG_DEBUG) \
+        printf("\033[90m[DEBUG]\033[0m " fmt "\n", ##__VA_ARGS__); \
+} while(0)
+
+#endif /* B_LOG_H */


### PR DESCRIPTION
## Summary

Comprehensive quality overhaul + complete Mach-O format support matching ELF analysis capabilities.

**Two commits:**
1. `fix: critical bugs, add tests, CI, and code quality improvements`
2. `feat: complete Mach-O analysis with full ELF parity`

---

## Critical Bug Fixes
- **`debugger.c` memset bug**: `memset(ctx, 0, sizeof(ctx))` only cleared 8 bytes instead of full `context` struct
- **`destroy_bp_sym()` memory leak**: Wrong loop variable -- symbol list was never freed
- **`handle_action()` UB**: Missing `return` on fallthrough path
- **CLI memory leaks**: `free(line)` missing on 12 `continue` paths; `strdup`'d args never freed
- **NULL deref in vmmap**: `/proc/pid/maps` fopen failure not checked
- **Buffer overflow**: `sprintf` replaced with `snprintf`

## ELF Input Validation
- Minimum file size checks before casting to ELF structs
- Section/program header table bounds validation
- String table index and `sh_link` bounds checking

## Complete Mach-O Analysis (NEW -- ELF parity)

| Mode | Flag | Description |
|------|------|-------------|
| **Metadata** | `-m` | Full header, all 17+ load command types, symbol table, dysymtab, dylib paths, dynamic linker, UUID, build version, code signature |
| **Disassembly** | `-a` | x86/x86-64 disassembly with per-function symbol labels from LC_SYMTAB |
| **Debugger** | `-d` | ptrace debugger with Mach-O nlist symbol loading for breakpoint-by-name |
| **Decompiler** | `-c` | RetDec integration (format-agnostic) |

Key Mach-O changes:
- Fixed `dylib` and `dylinker_command` struct layouts (broken on-disk parsing)
- Added `nlist`/`nlist_64` structs and CPU type constants to `macho.h`
- Complete rewrite of `b_macho_metadata.c` with validation and handler-per-command architecture
- New `bx_macho_disasm` module with symbol-labeled disassembly using udis86
- Debugger auto-detects Mach-O magic and loads function symbols

## Test Suite (30 tests, 4 suites)
- `test_hashmap`: 6 tests
- `test_baseer_core`: 11 tests
- `test_bparser`: 7 tests
- `test_macho`: 6 tests (NEW)

## CI/CD Pipeline
- GitHub Actions: Release build + Debug build with AddressSanitizer + UBSan

## Security
- Replaced `system()` with `fork()/execl()` in decompiler
- RetDec path configurable via `BASEER_RETDEC_BIN` env var

## Code Cleanup
- Removed ~80 lines of dead commented-out code
- Fixed spelling errors, moved static arrays from headers to source
- Added centralized logging system (`utils/b_log.h`)
- Added `CHANGELOG.md`, updated README with badges and env var docs

## Stats
- **+2,571 lines added, -906 removed** across 32 files
- 4 test suites, 30 total tests, 2 CI jobs, zero failures