### PR TITLE
fix: harden Mach-O hex dump bounds check and clean up magic numbers

### DIFF
--- a/modules/b_macho_metadata/b_macho_metadata.c
+++ b/modules/b_macho_metadata/b_macho_metadata.c
@@ -25,7 +25,6 @@
 #include "../../utils/ui.h"
 #include <stdio.h>
 #include <string.h>
-#include <stdlib.h>
 
 /* =================== Validation helpers =================== */
 
@@ -89,11 +88,10 @@ static void handle_segment_64(const unsigned char *cmd_ptr, const unsigned char 
             print_macho_section64_metadata(sec);
 
             /* Print hex dump of section contents */
-            if (sec->size > 0 && sec->offset + sec->size <= file_size) {
+            if (sec->size > 0 && (uint64_t)sec->offset + sec->size <= file_size) {
                 unsigned char *data = (unsigned char *)(block + sec->offset);
                 int flags = macho_section_is_executable(sec->flags) ? SHF_EXECINSTR : 0;
-                unsigned char bit_type = 2; /* ELFCLASS64 = 2, used for 64-bit disasm mode */
-                print_body_bytes(data, sec->size, sec->addr, flags, bit_type);
+                print_body_bytes(data, sec->size, sec->addr, flags, ELFCLASS64);
             }
 
             sec_ptr += sizeof(section_64);
@@ -115,11 +113,10 @@ static void handle_segment_32(const unsigned char *cmd_ptr, const unsigned char 
             print_macho_section32_metadata(sec);
 
             /* Print hex dump of section contents */
-            if (sec->size > 0 && sec->offset + sec->size <= file_size) {
+            if (sec->size > 0 && (uint64_t)sec->offset + sec->size <= file_size) {
                 unsigned char *data = (unsigned char *)(block + sec->offset);
                 int flags = macho_section_is_executable(sec->flags) ? SHF_EXECINSTR : 0;
-                unsigned char bit_type = 1; /* ELFCLASS32 = 1, used for 32-bit disasm mode */
-                print_body_bytes(data, sec->size, sec->addr, flags, bit_type);
+                print_body_bytes(data, sec->size, sec->addr, flags, ELFCLASS32);
             }
 
             sec_ptr += sizeof(section);


### PR DESCRIPTION
## Summary
- Fix integer overflow in Mach-O section bounds check by casting `sec->offset` to `uint64_t` before addition (both 32-bit and 64-bit handlers)
- Replace magic numbers `1`/`2` with `ELFCLASS32`/`ELFCLASS64` constants for `print_body_bytes` bit_type parameter
- Remove unused `#include <stdlib.h>`

## Test plan
- [ ] Build the project and verify no new warnings from `b_macho_metadata.c`
- [ ] Test with 32-bit and 64-bit Mach-O binaries to verify hex dump output is unchanged
- [ ] Test with a malformed Mach-O binary with large offset/size values to verify bounds check catches overflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)