### PR TITLE
feat: add PDF format support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,6 +51,8 @@ set(BX_MACHO_SRC modules/bx_macho/bx_macho.c)
 set(BX_MACHO_UTILS_SRC modules/bx_macho_utils/bx_macho_utils.c)
 set(B_MACHO_METADATA_SRC modules/b_macho_metadata/b_macho_metadata.c)
 set(BX_MACHO_DISASM_SRC modules/bx_macho_disasm/bx_macho_disasm.c)
+set(BX_PDF_SRC modules/bx_pdf/bx_pdf.c)
+set(B_PDF_METADATA_SRC modules/b_pdf_metadata/b_pdf_metadata.c)
 
 # Main executable
 add_executable(baseer
@@ -70,6 +72,8 @@ add_executable(baseer
     ${BX_MACHO_UTILS_SRC}
     ${B_MACHO_METADATA_SRC}
     ${BX_MACHO_DISASM_SRC}
+    ${BX_PDF_SRC}
+    ${B_PDF_METADATA_SRC}
     ${UDIS86_SRC}
 )
 
@@ -87,11 +91,14 @@ add_library(bx_deElf SHARED ${BX_deElf_SRC})
 # Modules that need udis86
 add_library(b_debugger SHARED ${B_DEBUG_SRC} ${UDIS86_SRC})
 add_library(bx_elf_disasm SHARED ${BX_ELF_DISASM_SRC} ${UDIS86_SRC})
+add_library(bx_pdf SHARED ${BX_PDF_SRC})
+add_library(b_pdf_metadata SHARED ${B_PDF_METADATA_SRC})
 
 # Set output directory for modules
 set_target_properties(
-    bx_binhead bparser b_hashmap bx_elf b_elf_metadata 
+    bx_binhead bparser b_hashmap bx_elf b_elf_metadata
     b_debugger bx_tar bx_deElf bx_elf_disasm
+    bx_pdf b_pdf_metadata
     PROPERTIES
     LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/modules"
 )
@@ -99,8 +106,9 @@ set_target_properties(
 # Installation rules
 install(TARGETS baseer DESTINATION ${BINDIR})
 install(TARGETS 
-    bx_binhead bparser b_hashmap bx_elf b_elf_metadata 
+    bx_binhead bparser b_hashmap bx_elf b_elf_metadata
     b_debugger bx_tar bx_deElf bx_elf_disasm
+    bx_pdf b_pdf_metadata
     LIBRARY DESTINATION ${LIBDIR}
 )
 install(FILES README.md LICENSE DESTINATION ${BINDIR})
@@ -151,10 +159,21 @@ add_executable(test_macho
 target_include_directories(test_macho PRIVATE libs/linenoise)
 add_test(NAME test_macho COMMAND test_macho WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
 
+# Test: PDF
+add_executable(test_pdf
+    tests/test_pdf.c
+    modules/bparser/bparser.c
+    baseer.c
+    libs/linenoise/linenoise.c
+    ${B_HASHMAP_SRC}
+)
+target_include_directories(test_pdf PRIVATE libs/linenoise)
+add_test(NAME test_pdf COMMAND test_pdf WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
+
 # Custom target to run all tests
 add_custom_target(check
     COMMAND ${CMAKE_CTEST_COMMAND} --output-on-failure
-    DEPENDS test_hashmap test_baseer_core test_bparser test_macho
+    DEPENDS test_hashmap test_baseer_core test_bparser test_macho test_pdf
     COMMENT "Running all tests"
 )
 

--- a/examples/test_pdf
+++ b/examples/test_pdf
@@ -1,0 +1,25 @@
+%PDF-1.4
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Kids [3 0 R] /Count 1 >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] >>
+endobj
+4 0 obj
+<< /Title (Test Document) /Author (Baseer Test) /Creator (Python) /Producer (Test Producer) /CreationDate (D:20250101120000) >>
+endobj
+xref
+0 5
+0000000000 65535 f 
+0000000009 00000 n 
+0000000058 00000 n 
+0000000115 00000 n 
+0000000196 00000 n 
+trailer
+<< /Size 5 /Root 1 0 R /Info 4 0 R >>
+startxref
+344
+%%EOF

--- a/modules/b_pdf_metadata/b_pdf_metadata.c
+++ b/modules/b_pdf_metadata/b_pdf_metadata.c
@@ -1,0 +1,318 @@
+/**
+ * @file b_pdf_metadata.c
+ * @brief PDF metadata parser and pretty-printer.
+ */
+#define _GNU_SOURCE
+#include "./b_pdf_metadata.h"
+#include "../bparser/bparser.h"
+#include "../../baseer.h"
+#include "../../utils/ui.h"
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+#include <ctype.h>
+
+/* =================== Helpers =================== */
+
+static const char *find_backwards(const char *block, size_t size, const char *keyword)
+{
+    size_t klen = strlen(keyword);
+    if (size < klen) return NULL;
+
+    for (size_t i = size - klen; ; i--) {
+        if (memcmp(block + i, keyword, klen) == 0)
+            return block + i;
+        if (i == 0) break;
+    }
+    return NULL;
+}
+
+static const char *find_forward(const char *start, const char *end, const char *keyword)
+{
+    size_t klen = strlen(keyword);
+    size_t haystack_len = end - start;
+    if (haystack_len < klen) return NULL;
+    return memmem(start, haystack_len, keyword, klen);
+}
+
+static bool extract_dict_value(const char *dict_start, const char *dict_end,
+                               const char *key, char *buf, size_t bufsize)
+{
+    char search[128];
+    snprintf(search, sizeof(search), "/%s", key);
+    size_t slen = strlen(search);
+
+    const char *p = find_forward(dict_start, dict_end, search);
+    if (!p) return false;
+
+    p += slen;
+
+    while (p < dict_end && (*p == ' ' || *p == '\t' || *p == '\r' || *p == '\n'))
+        p++;
+
+    size_t i = 0;
+
+    if (*p == '(') {
+        const char *open = p;
+        p++;
+        int depth = 1;
+        while (p < dict_end && i < bufsize - 1 && depth > 0) {
+            if (*p == '\\') {
+                /* Escaped character — copy both backslash and next char */
+                if (i < bufsize - 2 && p + 1 < dict_end) {
+                    buf[i++] = *p++;
+                    buf[i++] = *p++;
+                } else {
+                    break;
+                }
+                continue;
+            }
+            if (*p == '(') depth++;
+            else if (*p == ')') { depth--; if (depth == 0) break; }
+            buf[i++] = *p++;
+        }
+        (void)open;
+    } else if (*p == '<' && p + 1 < dict_end && *(p + 1) != '<') {
+        p++;
+        while (p < dict_end && *p != '>' && i < bufsize - 1)
+            buf[i++] = *p++;
+    } else {
+        while (p < dict_end && i < bufsize - 1) {
+            if (*p == '/' || (*p == '>' && p + 1 < dict_end && *(p + 1) == '>'))
+                break;
+            if (*p == '\r' || *p == '\n') break;
+            buf[i++] = *p++;
+        }
+    }
+
+    buf[i] = '\0';
+
+    while (i > 0 && (buf[i - 1] == ' ' || buf[i - 1] == '\t'))
+        buf[--i] = '\0';
+
+    return i > 0;
+}
+
+static unsigned int count_occurrences(const char *block, size_t size, const char *pattern)
+{
+    unsigned int count = 0;
+    size_t plen = strlen(pattern);
+    if (size < plen) return 0;
+
+    const char *p = block;
+    const char *end = block + size;
+    while ((p = memmem(p, end - p, pattern, plen)) != NULL) {
+        count++;
+        p += plen;
+    }
+    return count;
+}
+
+/**
+ * @brief Count /Type /Page (but not /Type /Pages) occurrences in a single pass.
+ */
+static unsigned int count_pages(const char *block, size_t size)
+{
+    unsigned int count = 0;
+    const char *p = block;
+    const char *end = block + size;
+    const char *type_str = "/Type";
+    size_t type_len = 5;
+
+    while ((p = memmem(p, end - p, type_str, type_len)) != NULL) {
+        const char *q = p + type_len;
+
+        /* Skip optional whitespace between /Type and /Page */
+        while (q < end && (*q == ' ' || *q == '\t'))
+            q++;
+
+        if (q + 5 <= end && memcmp(q, "/Page", 5) == 0) {
+            const char *after = q + 5;
+            /* Exclude /Pages (the catalog object) */
+            if (after < end && isalpha((unsigned char)*after)) {
+                p = after;
+                continue;
+            }
+            count++;
+        }
+        p = q;
+    }
+    return count;
+}
+
+/* =================== Metadata printers =================== */
+
+static void print_pdf_header(const char *block, size_t size)
+{
+    printf(COLOR_BLUE "================= PDF Header ====================\n" COLOR_RESET);
+
+    if (size >= 8 && memcmp(block, "%PDF-", 5) == 0) {
+        char version[16] = {0};
+        for (int i = 5; i < 15 && i < (int)size; i++) {
+            if (block[i] == '\r' || block[i] == '\n') break;
+            version[i - 5] = block[i];
+        }
+        printf(COLOR_GREEN "PDF Version:       " COLOR_RESET "%s\n", version);
+    }
+
+    const char *lin = find_forward(block, block + (size > 1024 ? 1024 : size), "/Linearized");
+    printf(COLOR_GREEN "Linearized:        " COLOR_RESET "%s\n", lin ? "Yes" : "No");
+}
+
+static void print_pdf_trailer(const char *trailer, const char *block, size_t size)
+{
+    if (!trailer) {
+        printf(COLOR_BLUE "\n================= Trailer ====================\n" COLOR_RESET);
+        printf(COLOR_YELLOW "    (No traditional trailer found — may use cross-reference streams)\n" COLOR_RESET);
+        return;
+    }
+
+    const char *end = block + size;
+    const char *dict_start = find_forward(trailer, end, "<<");
+    const char *dict_end = find_forward(trailer, end, ">>");
+    if (!dict_start || !dict_end || dict_end <= dict_start) return;
+
+    printf(COLOR_BLUE "\n================= Trailer ====================\n" COLOR_RESET);
+
+    char buf[256];
+
+    if (extract_dict_value(dict_start, dict_end, "Size", buf, sizeof(buf)))
+        printf(COLOR_GREEN "    Size:          " COLOR_RESET "%s objects\n", buf);
+
+    if (extract_dict_value(dict_start, dict_end, "Root", buf, sizeof(buf)))
+        printf(COLOR_GREEN "    Root:          " COLOR_RESET "%s\n", buf);
+
+    if (extract_dict_value(dict_start, dict_end, "Info", buf, sizeof(buf)))
+        printf(COLOR_GREEN "    Info:          " COLOR_RESET "%s\n", buf);
+
+    if (extract_dict_value(dict_start, dict_end, "Encrypt", buf, sizeof(buf)))
+        printf(COLOR_GREEN "    Encrypt:       " COLOR_RESET "%s\n", buf);
+
+    if (extract_dict_value(dict_start, dict_end, "ID", buf, sizeof(buf)))
+        printf(COLOR_GREEN "    ID:            " COLOR_RESET "%s\n", buf);
+}
+
+static void print_pdf_xref(const char *block, size_t size)
+{
+    const char *xref = find_backwards(block, size, "startxref");
+    if (!xref) return;
+
+    printf(COLOR_BLUE "\n================= Cross-Reference ====================\n" COLOR_RESET);
+
+    const char *p = xref + 9;
+    const char *end = block + size;
+    while (p < end && (*p == ' ' || *p == '\r' || *p == '\n'))
+        p++;
+
+    char offset_str[32] = {0};
+    int i = 0;
+    while (p < end && isdigit((unsigned char)*p) && i < 30)
+        offset_str[i++] = *p++;
+
+    if (i > 0)
+        printf(COLOR_GREEN "    XRef Offset:   " COLOR_RESET "%s\n", offset_str);
+
+    unsigned int xref_count = count_occurrences(block, size, "xref");
+    unsigned int startxref_count = count_occurrences(block, size, "startxref");
+    if (xref_count >= startxref_count)
+        xref_count -= startxref_count;
+    printf(COLOR_GREEN "    XRef Tables:   " COLOR_RESET "%u\n", xref_count);
+}
+
+static void print_pdf_info_dict(const char *trailer, const char *block, size_t size)
+{
+    if (!trailer) return;
+
+    const char *end = block + size;
+    const char *dict_start = find_forward(trailer, end, "<<");
+    const char *dict_end = find_forward(trailer, end, ">>");
+    if (!dict_start || !dict_end) return;
+
+    char info_ref[64] = {0};
+    if (!extract_dict_value(dict_start, dict_end, "Info", info_ref, sizeof(info_ref)))
+        return;
+
+    int obj_num = atoi(info_ref);
+    if (obj_num <= 0) return;
+
+    char obj_marker[32];
+    snprintf(obj_marker, sizeof(obj_marker), "%d 0 obj", obj_num);
+
+    const char *obj_start = find_forward(block, end, obj_marker);
+    if (!obj_start) return;
+
+    const char *obj_dict_start = find_forward(obj_start, end, "<<");
+    const char *obj_end = find_forward(obj_start, end, "endobj");
+    if (!obj_dict_start || !obj_end) return;
+
+    const char *obj_dict_end = find_forward(obj_dict_start + 2, obj_end, ">>");
+    if (!obj_dict_end) return;
+
+    printf(COLOR_BLUE "\n================= Document Info ====================\n" COLOR_RESET);
+
+    char buf[512];
+    const char *keys[] = {"Title", "Author", "Subject", "Keywords", "Creator",
+                          "Producer", "CreationDate", "ModDate", NULL};
+
+    for (int k = 0; keys[k] != NULL; k++) {
+        if (extract_dict_value(obj_dict_start, obj_dict_end, keys[k], buf, sizeof(buf)))
+            printf(COLOR_GREEN "    %-15s" COLOR_RESET "%s\n", keys[k], buf);
+    }
+}
+
+static void print_pdf_statistics(const char *block, size_t size)
+{
+    printf(COLOR_BLUE "\n================= Statistics ====================\n" COLOR_RESET);
+
+    unsigned int obj_count = count_occurrences(block, size, " obj");
+    printf(COLOR_GREEN "    Objects:       " COLOR_RESET "%u\n", obj_count);
+
+    unsigned int stream_count = count_occurrences(block, size, "stream\r");
+    stream_count += count_occurrences(block, size, "stream\n");
+    unsigned int endstream_count = count_occurrences(block, size, "endstream");
+    if (stream_count >= endstream_count)
+        stream_count -= endstream_count;
+    printf(COLOR_GREEN "    Streams:       " COLOR_RESET "%u\n", stream_count);
+
+    unsigned int page_count = count_pages(block, size);
+    printf(COLOR_GREEN "    Pages:         " COLOR_RESET "%u\n", page_count);
+
+    bool encrypted = find_forward(block, block + size, "/Encrypt") != NULL;
+    printf(COLOR_GREEN "    Encrypted:     " COLOR_RESET "%s\n", encrypted ? "Yes" : "No");
+
+    printf(COLOR_GREEN "    File Size:     " COLOR_RESET "%zu bytes\n", size);
+}
+
+/* =================== Public entry point =================== */
+
+bool b_pdf_metadata(bparser *parser, void *arg)
+{
+    if (!parser || !parser->block) {
+        fprintf(stderr, COLOR_RED "[!] Invalid parser state\n" COLOR_RESET);
+        return false;
+    }
+
+    const char *block = (const char *)parser->block;
+    size_t size = parser->size;
+
+    if (size < 8) {
+        fprintf(stderr, COLOR_RED "[!] File too small to be a valid PDF\n" COLOR_RESET);
+        return false;
+    }
+
+    if (memcmp(block, "%PDF-", 5) != 0) {
+        fprintf(stderr, COLOR_RED "[!] Not a valid PDF file (missing %%PDF- header)\n" COLOR_RESET);
+        return false;
+    }
+
+    const char *trailer = find_backwards(block, size, "trailer");
+
+    print_pdf_header(block, size);
+    print_pdf_trailer(trailer, block, size);
+    print_pdf_xref(block, size);
+    print_pdf_info_dict(trailer, block, size);
+    print_pdf_statistics(block, size);
+
+    printf("\n");
+    return true;
+}

--- a/modules/b_pdf_metadata/b_pdf_metadata.h
+++ b/modules/b_pdf_metadata/b_pdf_metadata.h
@@ -1,0 +1,9 @@
+#ifndef B_PDF_METADATA_H
+#define B_PDF_METADATA_H
+
+#include "../../baseer.h"
+#include "../bparser/bparser.h"
+
+bool b_pdf_metadata(bparser* parser, void* arg);
+
+#endif

--- a/modules/binhead/bx_binhead.c
+++ b/modules/binhead/bx_binhead.c
@@ -7,6 +7,7 @@
 #include "../bx_elf/bx_elf.h"
 #include "../bx_tar/bx_tar.h"
 #include "../bx_macho/bx_macho.h"
+#include "../bx_pdf/bx_pdf.h"
 
 unsigned int count_bits(unsigned long long int n)
 {
@@ -74,6 +75,7 @@ bool bx_binhead(baseer_target_t *target, void *arg)
         {"TAR", TAR_MAGIC, reverse_bytes(TAR_MAGIC), bx_tar, 257},
         {"Mach-o", MH_MAGIC, NXSwapInt(MH_MAGIC), bx_macho, 0},
         {"Mach-o", MH_MAGIC_64, NXSwapInt(MH_MAGIC_64), bx_macho, 0},
+        {"PDF", PDF_MAGIC, reverse_bytes(PDF_MAGIC), bx_pdf, 0},
     };
 
 

--- a/modules/bx_pdf/bx_pdf.c
+++ b/modules/bx_pdf/bx_pdf.c
@@ -1,0 +1,30 @@
+/**
+ * @file bx_pdf.c
+ * @brief PDF format handler for Baseer.
+ *
+ * Dispatches PDF analysis based on command-line flags:
+ *   -m  Metadata (header, trailer, xref, objects summary)
+ */
+#include "./bx_pdf.h"
+#include "../../baseer.h"
+#include "../b_pdf_metadata/b_pdf_metadata.h"
+#include <string.h>
+#include <stdio.h>
+
+bool bx_pdf(bparser *parser, void *arg)
+{
+    int argc = *((inputs *)arg)->argc;
+    char **args = ((inputs *)arg)->args;
+
+    for (int i = 2; i < argc; i++) {
+        if (strcmp("-m", args[i]) == 0) {
+            bparser_apply(parser, b_pdf_metadata, arg);
+        } else if (strcmp("--args", args[i]) == 0) {
+            break;
+        } else {
+            fprintf(stderr, "[!] Unsupported flag for PDF: %s\n", args[i]);
+        }
+    }
+
+    return true;
+}

--- a/modules/bx_pdf/bx_pdf.h
+++ b/modules/bx_pdf/bx_pdf.h
@@ -1,0 +1,7 @@
+#ifndef BX_PDF_H
+#define BX_PDF_H
+#include "../bparser/bparser.h"
+
+bool bx_pdf(bparser* parser, void *arg);
+
+#endif

--- a/tests/test_pdf.c
+++ b/tests/test_pdf.c
@@ -1,0 +1,82 @@
+/**
+ * @file test_pdf.c
+ * @brief Unit tests for PDF parsing modules.
+ */
+#define _GNU_SOURCE
+#include "test_framework.h"
+#include <stdint.h>
+#include <string.h>
+#include "../baseer.h"
+#include "../modules/bparser/bparser.h"
+
+#define TEST_PDF "examples/test_pdf"
+
+TEST(test_pdf_file_opens) {
+    baseer_target_t *t = baseer_open(TEST_PDF, BASEER_MODE_MEMORY);
+    ASSERT_NOT_NULL(t);
+    ASSERT_NOT_NULL(t->block);
+    ASSERT(t->size > 0);
+    baseer_close(t);
+}
+
+TEST(test_pdf_magic) {
+    baseer_target_t *t = baseer_open(TEST_PDF, BASEER_MODE_MEMORY);
+    ASSERT_NOT_NULL(t);
+    unsigned char *data = (unsigned char *)t->block;
+    ASSERT(data[0] == 0x25); /* % */
+    ASSERT(data[1] == 0x50); /* P */
+    ASSERT(data[2] == 0x44); /* D */
+    ASSERT(data[3] == 0x46); /* F */
+    ASSERT(data[4] == 0x2D); /* - */
+    baseer_close(t);
+}
+
+TEST(test_pdf_version) {
+    baseer_target_t *t = baseer_open(TEST_PDF, BASEER_MODE_MEMORY);
+    ASSERT_NOT_NULL(t);
+    unsigned char *data = (unsigned char *)t->block;
+    ASSERT(t->size >= 8);
+    ASSERT(data[5] >= '0' && data[5] <= '9');
+    baseer_close(t);
+}
+
+TEST(test_pdf_bparser_load) {
+    baseer_target_t *t = baseer_open(TEST_PDF, BASEER_MODE_BOTH);
+    ASSERT_NOT_NULL(t);
+    bparser *bp = bparser_load(t);
+    ASSERT_NOT_NULL(bp);
+    ASSERT_EQ(bp->size, t->size);
+
+    unsigned char buf[5] = {0};
+    size_t n = bparser_read(bp, buf, 0, 5);
+    ASSERT_EQ(n, 5);
+    ASSERT(memcmp(buf, "%PDF-", 5) == 0);
+
+    free(bp);
+    baseer_close(t);
+}
+
+TEST(test_pdf_has_trailer) {
+    baseer_target_t *t = baseer_open(TEST_PDF, BASEER_MODE_MEMORY);
+    ASSERT_NOT_NULL(t);
+    ASSERT(memmem(t->block, t->size, "trailer", 7) != NULL);
+    baseer_close(t);
+}
+
+TEST(test_pdf_has_eof) {
+    baseer_target_t *t = baseer_open(TEST_PDF, BASEER_MODE_MEMORY);
+    ASSERT_NOT_NULL(t);
+    ASSERT(memmem(t->block, t->size, "%%EOF", 5) != NULL);
+    baseer_close(t);
+}
+
+int main(void) {
+    printf("\n=== PDF Tests ===\n");
+    RUN_TEST(test_pdf_file_opens);
+    RUN_TEST(test_pdf_magic);
+    RUN_TEST(test_pdf_version);
+    RUN_TEST(test_pdf_bparser_load);
+    RUN_TEST(test_pdf_has_trailer);
+    RUN_TEST(test_pdf_has_eof);
+    TEST_REPORT();
+}


### PR DESCRIPTION
## Summary
- Add PDF as a new supported binary format following the existing module pattern (`bx_pdf` handler + `b_pdf_metadata` parser)
- Metadata extraction includes: PDF version, linearization status, trailer dictionary, cross-reference table info, document info (Title, Author, Subject, Keywords, Creator, Producer, dates), and file statistics (object/stream/page counts, encryption, file size)
- Register `PDF_MAGIC` (`%PDF-`) in `bx_binhead` magic number dispatcher
- Add unit tests (`test_pdf.c`) and test fixture (`examples/test_pdf`)

## Test plan
- [x] All 5 tests pass (`test_hashmap`, `test_baseer_core`, `test_bparser`, `test_macho`, `test_pdf`)
- [x] `./build/baseer examples/test_pdf -m` displays correct metadata output
- [x] Existing formats (ELF, TAR, Mach-O) unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)