### PR TITLE
feat: add Claude Code pipeline orchestrator (bun)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,34 @@
 *.app
 a.out
 
+# Node.js / Bun
+node_modules/
+dist/
+.pnp.*
+.yarn/
+
+# Lock files from other package managers (we use bun)
+package-lock.json
+pnpm-lock.yaml
+yarn.lock
+
+# Secrets / credentials
+.env
+.env.*
+!.env.example
+*.pem
+*.key
+credentials*
+secrets*
+.npmrc
+.netrc
+*.p12
+*.pfx
+id_rsa
+id_dsa
+id_ecdsa
+id_ed25519
+
 # Debug / profiling
 *.dSYM/
 *.stackdump

--- a/README.md
+++ b/README.md
@@ -72,39 +72,45 @@ Each branch in the diagram represents a callback path from the main function →
 ---
 ## Build Instructions
 
-Baseer uses a standard Makefile for compilation.
+Baseer uses CMake for compilation.
+
+### Requirements
+- GCC
+- CMake (>= 3.10)
+- Linux environment
 
 ### Clone the repository
 ```bash
 git clone https://github.com/thxa/baseer.git
 cd baseer
 ```
+
 ### Build Baseer
+Out-of-source build (recommended — keeps the repo clean):
 ```bash
-cmake CMakeLists.txt
-make
+cmake -S . -B build
+cmake --build build
 ```
 
 ### Run Baseer on a binary
-```
-./build/baseer <target-file> -m
+```bash
+./build/baseer <target-file> -m        # show metadata
+./build/baseer <target-file> -a        # disassemble
+./build/baseer <target-file> -d        # debugger
+./build/baseer <target-file> -c        # decompile
+./build/baseer -i                      # interactive REPL
 ```
 
 ### Compile and analyze file
 - 64 bit
-```bash 
-cmake CMakeLists.txt && make && ./build/baseer examples/64bit_x86_64 -m | less -r
+```bash
+cmake -S . -B build && cmake --build build && ./build/baseer examples/64bit_x86_64 -m | less -r
 ```
 
 - 32 bit
-```bash 
-cmake CMakeLists.txt && make && ./build/baseer examples/32bit_x86 -m | less -r
+```bash
+cmake -S . -B build && cmake --build build && ./build/baseer examples/32bit_x86 -m | less -r
 ```
-
-### Requirements
-- GCC
-- CMake (>= 3.10)
-- Linux environment
 
 ### Run Tests
 ```bash
@@ -142,12 +148,12 @@ pacman -Rs baseer
 ### Install from Source
 To install **Baseer** from source:
 ```bash
-cmake CMakeLists.txt && make install
+cmake -S . -B build && sudo cmake --build build --target install
 ```
 
 To uninstall:
 ```bash
-cmake CMakeLists.txt && make uninstall
+sudo cmake --build build --target uninstall
 ```
 ---
 

--- a/bun.lock
+++ b/bun.lock
@@ -1,0 +1,20 @@
+{
+  "lockfileVersion": 1,
+  "configVersion": 0,
+  "workspaces": {
+    "": {
+      "name": "baseer-pipeline",
+      "devDependencies": {
+        "@types/node": "^22.0.0",
+        "typescript": "^5.7.0",
+      },
+    },
+  },
+  "packages": {
+    "@types/node": ["@types/node@22.19.17", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q=="],
+
+    "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+
+    "undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "baseer-pipeline",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "pipeline": "bun pipeline/run.ts"
+  },
+  "devDependencies": {
+    "typescript": "^5.7.0",
+    "@types/node": "^22.0.0"
+  }
+}

--- a/pipeline/run.ts
+++ b/pipeline/run.ts
@@ -1,0 +1,249 @@
+import { spawn } from "node:child_process";
+import { randomUUID } from "node:crypto";
+import path from "node:path";
+
+// ── Types ──────────────────────────────────────────────────────────────────────
+
+interface ClaudeResult {
+  type: string;
+  subtype: string;
+  result: string;
+  session_id: string;
+  total_cost_usd: number;
+  num_turns: number;
+  is_error: boolean;
+}
+
+// ── Config ─────────────────────────────────────────────────────────────────────
+
+const CWD = process.cwd();
+const WORKTREE_NAME = `pipeline-${randomUUID().slice(0, 8)}`;
+
+// ── Helpers ────────────────────────────────────────────────────────────────────
+
+function log(phase: string, msg: string) {
+  const dim = "\x1b[2m";
+  const cyan = "\x1b[36m";
+  const reset = "\x1b[0m";
+  const bold = "\x1b[1m";
+  console.log(`${dim}──${reset} ${cyan}${bold}[${phase}]${reset} ${msg}`);
+}
+
+function logCost(result: ClaudeResult) {
+  const dim = "\x1b[2m";
+  const reset = "\x1b[0m";
+  console.log(
+    `   ${dim}turns: ${result.num_turns} | cost: $${result.total_cost_usd.toFixed(4)}${reset}`
+  );
+}
+
+function fail(msg: string): never {
+  console.error(`\x1b[31mError:\x1b[0m ${msg}`);
+  process.exit(1);
+}
+
+/**
+ * Runs `claude` CLI in non-interactive mode and returns the parsed JSON result.
+ * Streams stderr (progress) to the terminal in real time.
+ */
+function runClaude(args: string[], cwd: string = CWD): Promise<ClaudeResult> {
+  return new Promise((resolve, reject) => {
+    const proc = spawn("claude", args, {
+      cwd,
+      stdio: ["ignore", "pipe", "inherit"],
+      env: { ...process.env },
+    });
+
+    let stdout = "";
+
+    proc.stdout.on("data", (chunk: Buffer) => {
+      stdout += chunk.toString();
+    });
+
+    proc.on("error", (err) => reject(new Error(`Failed to spawn claude: ${err.message}`)));
+
+    proc.on("close", (code) => {
+      if (code !== 0) {
+        reject(new Error(`claude exited with code ${code}\n${stdout}`));
+        return;
+      }
+      try {
+        const result = JSON.parse(stdout) as ClaudeResult;
+        if (result.is_error) {
+          reject(new Error(`Claude returned an error: ${result.result}`));
+          return;
+        }
+        resolve(result);
+      } catch {
+        reject(new Error(`Failed to parse claude output:\n${stdout.slice(0, 500)}`));
+      }
+    });
+  });
+}
+
+// ── Pipeline Steps ─────────────────────────────────────────────────────────────
+
+async function createWorktree(): Promise<string> {
+  log("Worktree", `Creating worktree: ${WORKTREE_NAME}`);
+
+  const worktreePath = path.resolve(CWD, "..", `baseer-${WORKTREE_NAME}`);
+  const branch = WORKTREE_NAME;
+
+  const proc = spawn("git", ["worktree", "add", "-b", branch, worktreePath], {
+    cwd: CWD,
+    stdio: "inherit",
+  });
+
+  await new Promise<void>((resolve, reject) => {
+    proc.on("error", reject);
+    proc.on("close", (code) =>
+      code === 0 ? resolve() : reject(new Error(`git worktree add failed (code ${code})`))
+    );
+  });
+
+  log("Worktree", `Created at ${worktreePath} (branch: ${branch})`);
+  return worktreePath;
+}
+
+async function plan(prompt: string, worktreePath: string): Promise<ClaudeResult> {
+  log("Plan", "Generating implementation plan...");
+
+  const result = await runClaude([
+    "--print",
+    "--output-format", "json",
+    "--permission-mode", "plan",
+    "--dangerously-skip-permissions",
+    prompt,
+  ], worktreePath);
+
+  log("Plan", "Plan created successfully.");
+  logCost(result);
+  return result;
+}
+
+async function implement(sessionId: string, worktreePath: string): Promise<ClaudeResult> {
+  log("Implement", "Implementing the plan...");
+
+  const result = await runClaude([
+    "--print",
+    "--output-format", "json",
+    "--resume", sessionId,
+    "--permission-mode", "acceptEdits",
+    "--dangerously-skip-permissions",
+    "Exit plan mode. Now implement the plan you created. Do the work step by step.",
+  ], worktreePath);
+
+  log("Implement", "Implementation complete.");
+  logCost(result);
+  return result;
+}
+
+async function simplify(sessionId: string, worktreePath: string): Promise<ClaudeResult> {
+  log("Simplify", "Running /simplify to clean up the code...");
+
+  const result = await runClaude([
+    "--print",
+    "--output-format", "json",
+    "--resume", sessionId,
+    "--permission-mode", "acceptEdits",
+    "--dangerously-skip-permissions",
+    "/simplify",
+  ], worktreePath);
+
+  log("Simplify", "Simplification complete.");
+  logCost(result);
+  return result;
+}
+
+async function commit(sessionId: string, worktreePath: string): Promise<ClaudeResult> {
+  log("Commit", "Committing changes...");
+
+  const result = await runClaude([
+    "--print",
+    "--output-format", "json",
+    "--resume", sessionId,
+    "--permission-mode", "acceptEdits",
+    "--dangerously-skip-permissions",
+    "/commit",
+  ], worktreePath);
+
+  log("Commit", "Changes committed.");
+  logCost(result);
+  return result;
+}
+
+async function openPR(sessionId: string, worktreePath: string): Promise<ClaudeResult> {
+  log("PR", "Opening pull request...");
+
+  const result = await runClaude([
+    "--print",
+    "--output-format", "json",
+    "--resume", sessionId,
+    "--permission-mode", "acceptEdits",
+    "--dangerously-skip-permissions",
+    "Create a pull request for these changes to main. Use `gh pr create` with a clear title and description summarizing what was done.",
+  ], worktreePath);
+
+  log("PR", "Pull request created.");
+  logCost(result);
+  return result;
+}
+
+async function cleanupWorktree(worktreePath: string) {
+  const dim = "\x1b[2m";
+  const reset = "\x1b[0m";
+  console.log(`\n${dim}Tip: when done, clean up the worktree with:${reset}`);
+  console.log(`  git worktree remove ${worktreePath}`);
+}
+
+// ── Main ───────────────────────────────────────────────────────────────────────
+
+async function main() {
+  const prompt = process.argv.slice(2).join(" ").trim();
+
+  if (!prompt) {
+    fail("Usage: bun pipeline 'YOUR PROMPT HERE'");
+  }
+
+  console.log("\n\x1b[1m🔧 Baseer Production Pipeline\x1b[0m\n");
+  console.log(`Prompt: ${prompt}\n`);
+
+  let totalCost = 0;
+  const trackCost = (r: ClaudeResult) => {
+    totalCost += r.total_cost_usd;
+    return r;
+  };
+
+  // Step 1: Create worktree
+  const worktreePath = await createWorktree();
+
+  try {
+    // Step 2: Plan
+    const planResult = trackCost(await plan(prompt, worktreePath));
+
+    // Step 3: Implement
+    const implResult = trackCost(await implement(planResult.session_id, worktreePath));
+
+    // Step 4: Simplify
+    const simpResult = trackCost(await simplify(implResult.session_id, worktreePath));
+
+    // Step 5: Commit
+    const commitResult = trackCost(await commit(simpResult.session_id, worktreePath));
+
+    // Step 6: Open PR
+    const prResult = trackCost(await openPR(commitResult.session_id, worktreePath));
+
+    // Summary
+    console.log("\n\x1b[32m\x1b[1m✓ Pipeline complete!\x1b[0m");
+    console.log(`  Total cost: $${totalCost.toFixed(4)}`);
+    console.log(`  PR result: ${prResult.result.slice(0, 200)}`);
+
+    await cleanupWorktree(worktreePath);
+  } catch (err) {
+    console.error(`\n\x1b[31mPipeline failed:\x1b[0m`, (err as Error).message);
+    await cleanupWorktree(worktreePath);
+    process.exit(1);
+  }
+}
+
+main();

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "outDir": "dist"
+  },
+  "include": ["pipeline/**/*.ts"]
+}


### PR DESCRIPTION
Adds a `bun pipeline 'PROMPT'` command that runs an end-to-end automation flow using the Claude CLI in non-interactive mode: creates a git worktree, plans in plan mode, implements, runs /simplify, /commit, and opens a PR. Each phase resumes the previous Claude session so full context is preserved.

Also updates README build instructions to use out-of-source CMake builds and hardens .gitignore against secrets and stray lock files.