### PR TITLE
feat: repeat last debugger command on Enter

### DIFF
--- a/modules/b_debugger/debugger.c
+++ b/modules/b_debugger/debugger.c
@@ -110,8 +110,18 @@ void parse_cmd(context *ctx){
 	bool flag = false;
         char *cmd = linenoise(COLOR_WHITE"Baseer-\033[5;34mDBG"COLOR_RESET"-> "COLOR_RESET);
         if(!cmd) return;
-        if(*cmd) linenoiseHistoryAdd(cmd);
 	cmd[strcspn(cmd, "\n")] = 0;
+	if(*cmd){
+		linenoiseHistoryAdd(cmd);
+		free(ctx->last_cmd);
+		ctx->last_cmd = strdup(cmd);
+	} else if(ctx->last_cmd){
+		free(cmd);
+		cmd = strdup(ctx->last_cmd);
+	} else {
+		free(cmd);
+		return;
+	}
 	char *op ;
 	char *args ;
 
@@ -956,6 +966,8 @@ void destroy_all(context *ctx){
 	destroy_bp_sym(ctx);
 	free(ctx->list);
 	ctx->list = NULL;
+	free(ctx->last_cmd);
+	ctx->last_cmd = NULL;
 	free(ctx);
 	ctx = NULL;
 }

--- a/modules/b_debugger/debugger.h
+++ b/modules/b_debugger/debugger.h
@@ -110,6 +110,7 @@ struct context {
     bool do_wait;               /**< Whether to wait for process stop */
     bool pie;                   /**< True if the target binary is Position Independent Executable (PIE) */
     bool do_exit;               /**< Set when the debugger should terminate */
+    char *last_cmd;             /**< Last entered command line (for Enter repeat) */
 };
 
 /* ==== Function Prototypes ==== */


### PR DESCRIPTION
## Summary
- Pressing Enter on an empty prompt now repeats the last entered command, similar to GDB behavior
- Stores the full command line (including arguments) in `ctx->last_cmd` so commands like `x 0x400000` repeat correctly
- Properly frees `last_cmd` in `destroy_all` to avoid memory leaks

## Test plan
- [ ] Run the debugger, type `si`, press Enter — should step again
- [ ] Run `so`, press Enter — should step over again
- [ ] Press Enter with no prior command — should do nothing
- [ ] Commands with arguments (e.g., `x <addr>`) should repeat with the same arguments

🤖 Generated with [Claude Code](https://claude.com/claude-code)