### PR TITLE
fix: decompiler failing in GUI due to SIGCHLD conflict

### DIFF
--- a/gui/baseer_gui.c
+++ b/gui/baseer_gui.c
@@ -142,7 +142,15 @@ static char *capture_tool(AppState *st, const char *flag)
         }
     }
 
+    /* Temporarily restore default SIGCHLD so that tools using fork+waitpid
+     * (e.g. the decompiler's run_retdec) work correctly.  SIG_IGN causes
+     * automatic child reaping, which makes waitpid() return -1/ECHILD. */
+    struct sigaction old_sa;
+    sigaction(SIGCHLD, &(struct sigaction){ .sa_handler = SIG_DFL }, &old_sa);
+
     baseer_execute(st->target, bx_binhead, &input);
+
+    sigaction(SIGCHLD, &old_sa, NULL);
 
     free_map(input.map);
 

--- a/modules/bx_deElf/bx_deElf.c
+++ b/modules/bx_deElf/bx_deElf.c
@@ -238,23 +238,29 @@ static int dump_to_temp_file(bparser *parser, const char *path) {
         return -1;
     }
 
-    unsigned char buffer[parser->size];
-    unsigned int offset = 0; // new
+    #define CHUNK_SIZE (4 * 1024 * 1024) /* 4 MB */
+    unsigned char buffer[CHUNK_SIZE];
+    size_t pos = 0;
 
-    bparser_read(parser, buffer, offset, parser->size);
-    if (fwrite(buffer, 1, parser->size, out) != parser->size) {
-        perror("fwrite");
-        fclose(out);
-        return -1;
+    while (pos < parser->size) {
+        size_t to_read = parser->size - pos;
+        if (to_read > CHUNK_SIZE) to_read = CHUNK_SIZE;
+
+        size_t bytes_read = bparser_read(parser, buffer, pos, to_read);
+        if (bytes_read != to_read) {
+            fprintf(stderr, "[!] Failed to read binary at offset %zu (%zu of %zu bytes)\n",
+                    pos, bytes_read, to_read);
+            fclose(out);
+            return -1;
+        }
+        if (fwrite(buffer, 1, bytes_read, out) != bytes_read) {
+            perror("fwrite");
+            fclose(out);
+            return -1;
+        }
+        pos += bytes_read;
     }
-
-
-    // Optional: check if bparser_read failed
-    if (ferror(out)) {
-        perror("write error");
-        fclose(out);
-        return -1;
-    }
+    #undef CHUNK_SIZE
 
     fclose(out);
     return 0;
@@ -337,7 +343,7 @@ bool decompile_elf(bparser *parser, void *arg){
     close(out_fd);
 
     if (dump_to_temp_file(parser, in_path) != 0) {
-        perror("dump_tp_temp_file");
+        perror("dump_to_temp_file");
         unlink(in_path);
         unlink(out_path);
         return false;


### PR DESCRIPTION
## Summary
- **Fix SIGCHLD conflict**: The GUI sets `SIGCHLD` to `SIG_IGN` to auto-reap debugger terminal processes, but this breaks `waitpid()` in `run_retdec()` (returns `-1`/`ECHILD`), causing the decompiler to always fail. Fixed by temporarily restoring `SIG_DFL` around `baseer_execute()`.
- **Fix unsafe file I/O in `dump_to_temp_file()`**: Replaced unbounded stack VLA (`buffer[parser->size]`, up to 512MB) with chunked 4MB I/O, and added `bparser_read()` return value validation.
- **Fix typo**: `dump_tp_temp_file` → `dump_to_temp_file` in error message.

## Test plan
- [ ] Open a binary in baseer-gui and click Decompiler (Ctrl+E) — should produce decompiled C output instead of failing silently
- [ ] Verify debugger launch (Ctrl+D) still works (SIGCHLD restored to SIG_IGN after tool execution)
- [ ] Test with a large binary to verify chunked I/O handles files > 4MB correctly
- [ ] Run CLI decompiler (`baseer <file> -c`) to confirm no regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)