### PR TITLE
fix: resolve efficiency and safety issues in GUI and decompiler

### DIFF
--- a/gui/baseer_gui.c
+++ b/gui/baseer_gui.c
@@ -94,7 +94,8 @@ typedef struct {
     DbgState dbg;
 } AppState;
 
-static void strip_ansi(char *s)
+/* Strip ANSI escape sequences in-place, return new length. */
+static int strip_ansi(char *s)
 {
     char *r = s, *w = s;
     while (*r) {
@@ -111,12 +112,14 @@ static void strip_ansi(char *s)
         }
     }
     *w = '\0';
+    return (int)(w - s);
 }
 
+/* Count newline characters in text. */
 static int count_lines(const char *text)
 {
     if (!text || !*text) return 0;
-    int n = 1;
+    int n = 0;
     for (const char *p = text; *p; p++)
         if (*p == '\n') n++;
     return n;
@@ -127,7 +130,7 @@ static void set_output(AppState *st, char *text, const char *tool_name)
 {
     free(st->output);
     st->output = text;
-    st->content_h = count_lines(st->output) * LINE_HEIGHT;
+    st->content_h = (count_lines(st->output) + 1) * LINE_HEIGHT;
     st->scroll = (Vector2){ 0, 0 };
     st->active_tool = tool_name;
 }
@@ -303,8 +306,23 @@ static void dbg_append(DbgState *d, const char *data, int len)
     }
 }
 
-/* Read any available output from the PTY master (non-blocking).
- * Caps reads per frame to avoid stalling the render loop. */
+/* Read available PTY output, strip ANSI, and append to debugger buffer.
+ * Returns total bytes appended.  Pass max_bytes <= 0 for unlimited. */
+static int dbg_drain_fd(DbgState *d, int fd, int max_bytes)
+{
+    char tmp[4096];
+    int total = 0;
+    while (max_bytes <= 0 || total < max_bytes) {
+        ssize_t n = read(fd, tmp, sizeof(tmp) - 1);
+        if (n <= 0) break;
+        tmp[n] = '\0';
+        int slen = strip_ansi(tmp);
+        dbg_append(d, tmp, slen);
+        total += slen;
+    }
+    return total;
+}
+
 #define DBG_MAX_READ_PER_FRAME (16 * 1024)
 
 static void dbg_poll(AppState *st)
@@ -312,18 +330,9 @@ static void dbg_poll(AppState *st)
     DbgState *d = &st->dbg;
     if (!d->running || d->master_fd < 0) return;
 
-    int wstatus;
-    pid_t w = waitpid(d->pid, &wstatus, WNOHANG);
+    pid_t w = waitpid(d->pid, NULL, WNOHANG);
     if (w > 0 || (w < 0 && errno == ECHILD)) {
-        /* Child exited — drain remaining output */
-        char tmp[4096];
-        for (;;) {
-            ssize_t n = read(d->master_fd, tmp, sizeof(tmp) - 1);
-            if (n <= 0) break;
-            tmp[n] = '\0';
-            strip_ansi(tmp);
-            dbg_append(d, tmp, (int)strlen(tmp));
-        }
+        dbg_drain_fd(d, d->master_fd, 0);
         close(d->master_fd);
         d->master_fd = -1;
         d->running = false;
@@ -334,18 +343,8 @@ static void dbg_poll(AppState *st)
         return;
     }
 
-    char tmp[4096];
-    int total = 0;
-    while (total < DBG_MAX_READ_PER_FRAME) {
-        ssize_t n = read(d->master_fd, tmp, sizeof(tmp) - 1);
-        if (n <= 0) break;
-        tmp[n] = '\0';
-        strip_ansi(tmp);
-        int slen = (int)strlen(tmp);
-        dbg_append(d, tmp, slen);
-        total += slen;
+    if (dbg_drain_fd(d, d->master_fd, DBG_MAX_READ_PER_FRAME) > 0)
         d->auto_scroll = true;
-    }
 }
 
 static void dbg_send(AppState *st, const char *cmd)
@@ -513,24 +512,34 @@ static void draw_output(const char *text, Font font, Rectangle view, Vector2 scr
 {
     if (!text || !*text) return;
 
-    int y = (int)(view.y + scroll.y);
+    int y_start = (int)(view.y + scroll.y);
+    int view_top = (int)view.y;
     int view_bottom = (int)(view.y + view.height);
     const char *line = text;
 
+    /* Skip lines above the viewport */
+    if (y_start < view_top) {
+        int skip = (view_top - y_start) / LINE_HEIGHT;
+        for (int i = 0; i < skip && *line; i++) {
+            const char *eol = strchr(line, '\n');
+            line = eol ? eol + 1 : line + strlen(line);
+        }
+        y_start += skip * LINE_HEIGHT;
+    }
+
+    int y = y_start;
     while (*line) {
+        if (y > view_bottom) break;
+
         const char *eol = strchr(line, '\n');
         int len = eol ? (int)(eol - line) : (int)strlen(line);
 
-        if (y > view_bottom) break;  /* all remaining lines are below viewport */
-
-        if (y + LINE_HEIGHT >= (int)view.y) {
-            char buf[2048];
-            int n = len < (int)sizeof(buf) - 1 ? len : (int)sizeof(buf) - 1;
-            memcpy(buf, line, n);
-            buf[n] = '\0';
-            DrawTextEx(font, buf, (Vector2){ view.x + 8 + scroll.x, (float)y },
-                       OUTPUT_FONT_SIZE, 1, COL_TEXT);
-        }
+        char buf[2048];
+        int n = len < (int)sizeof(buf) - 1 ? len : (int)sizeof(buf) - 1;
+        memcpy(buf, line, n);
+        buf[n] = '\0';
+        DrawTextEx(font, buf, (Vector2){ view.x + 8 + scroll.x, (float)y },
+                   OUTPUT_FONT_SIZE, 1, COL_TEXT);
 
         y += LINE_HEIGHT;
         line = eol ? eol + 1 : line + len;

--- a/modules/bx_deElf/bx_deElf.c
+++ b/modules/bx_deElf/bx_deElf.c
@@ -238,8 +238,9 @@ static int dump_to_temp_file(bparser *parser, const char *path) {
         return -1;
     }
 
-    #define CHUNK_SIZE (4 * 1024 * 1024) /* 4 MB */
-    unsigned char buffer[CHUNK_SIZE];
+    #define CHUNK_SIZE (64 * 1024)
+    unsigned char *buffer = malloc(CHUNK_SIZE);
+    if (!buffer) { fclose(out); return -1; }
     size_t pos = 0;
 
     while (pos < parser->size) {
@@ -250,16 +251,19 @@ static int dump_to_temp_file(bparser *parser, const char *path) {
         if (bytes_read != to_read) {
             fprintf(stderr, "[!] Failed to read binary at offset %zu (%zu of %zu bytes)\n",
                     pos, bytes_read, to_read);
+            free(buffer);
             fclose(out);
             return -1;
         }
         if (fwrite(buffer, 1, bytes_read, out) != bytes_read) {
             perror("fwrite");
+            free(buffer);
             fclose(out);
             return -1;
         }
         pos += bytes_read;
     }
+    free(buffer);
     #undef CHUNK_SIZE
 
     fclose(out);


### PR DESCRIPTION
## Summary
- **Fix stack overflow risk**: Replace 4MB stack-allocated buffer with 64KB heap allocation in decompiler's `dump_to_temp_file`
- **Optimize rendering**: `draw_output()` now skips off-screen lines instead of scanning from line 0 every frame — O(visible) instead of O(total)
- **Eliminate redundant work**: `strip_ansi()` returns new length directly, removing a second `strlen()` pass on every PTY read chunk
- **Deduplicate PTY read loops**: Extract `dbg_drain_fd()` helper to replace two near-identical read-strip-append loops in `dbg_poll()`
- **Fix scroll jump bug**: `count_lines()` now returns newline count (0-based), consistent with incremental `line_count` tracking — prevents visual scroll jump after buffer trim
- **Remove unused variable**: `wstatus` in `dbg_poll()` was declared but never read

## Test plan
- [x] All 5 unit tests pass
- [x] GUI builds and launches successfully
- [x] Font loads correctly (JetBrains Mono Nerd Font at 2x)
- [ ] Verify debugger commands work (open file, Ctrl+D, type `h`, `i`, `q`)
- [ ] Verify decompiler still works with large binaries (heap buffer change)
- [ ] Scroll through large output to verify no rendering artifacts

🤖 Generated with [Claude Code](https://claude.com/claude-code)